### PR TITLE
Align nav menu with FAB right margin

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -206,7 +206,7 @@ li {
   gap: 0.5rem;
   position: absolute;
   top: 1.2rem;
-  right: 2rem;
+  right: var(--space-sm);
 }
 
 .toggle-btn,

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -18,6 +18,14 @@ test('fab container fixed to viewport corner', () => {
   assert.ok(/right:\s*10px/.test(block), 'fab container should be 10px from right');
 });
 
+test('nav toggles align with fab right margin', () => {
+  const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
+  const match = css.match(/\.toggles\s*{[\s\S]*?}/);
+  assert.ok(match, 'toggles styles not found');
+  const block = match[0];
+  assert.ok(/right:\s*var\(--space-sm\)/.test(block), 'toggles should use space-sm variable for right positioning');
+});
+
 // Ensure clicking outside or on backdrop closes mobile menu
 
 test('mobile menu closes on backdrop or outside click', async () => {


### PR DESCRIPTION
## Summary
- Align hamburger nav menu with FAB spacing by using shared spacing variable
- Add regression test to ensure nav menu aligns to right margin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898cd96b49c832b98366760e8dba592