### PR TITLE
Adjust FAB bottom spacing

### DIFF
--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -23,7 +23,7 @@ body {
 /* Floating Action Button (FAB) Container */
 .fab-container {
   position: fixed;
-  bottom: 40px;
+  bottom: 30px;
   right: 10px;
   z-index: 1000;
   display: flex;

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -14,7 +14,7 @@ test('fab container fixed to viewport corner', () => {
   assert.ok(match, 'fab-container styles not found');
   const block = match[0];
   assert.ok(/position:\s*fixed/.test(block), 'fab container should be fixed');
-  assert.ok(/bottom:\s*40px/.test(block), 'fab container should be 40px from bottom');
+  assert.ok(/bottom:\s*30px/.test(block), 'fab container should be 30px from bottom');
   assert.ok(/right:\s*10px/.test(block), 'fab container should be 10px from right');
 });
 


### PR DESCRIPTION
## Summary
- Move FAB container 30px from the bottom for consistent spacing
- Update layout test to expect new FAB offset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898cda56b88832b8c607d72033de843