### PR TITLE
Adjust FAB offset to avoid footer overlap

### DIFF
--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -23,8 +23,8 @@ body {
 /* Floating Action Button (FAB) Container */
 .fab-container {
   position: fixed;
-  bottom: 30px;
-  right: 10px;
+  bottom: 20px;
+  right: 15px;
   z-index: 1000;
   display: flex;
   flex-direction: column-reverse;

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -14,8 +14,8 @@ test('fab container fixed to viewport corner', () => {
   assert.ok(match, 'fab-container styles not found');
   const block = match[0];
   assert.ok(/position:\s*fixed/.test(block), 'fab container should be fixed');
-  assert.ok(/bottom:\s*30px/.test(block), 'fab container should be 30px from bottom');
-  assert.ok(/right:\s*10px/.test(block), 'fab container should be 10px from right');
+  assert.ok(/bottom:\s*20px/.test(block), 'fab container should be 20px from bottom');
+  assert.ok(/right:\s*15px/.test(block), 'fab container should be 15px from right');
 });
 
 test('nav toggles align with fab right margin', () => {


### PR DESCRIPTION
## Summary
- position floating action button 20px from bottom and 15px from right for better spacing above footer
- update UI test to expect new FAB offsets

## Testing
- `npm test`
- `NODE_PATH=./node_modules node /tmp/verify_fab.js`


------
https://chatgpt.com/codex/tasks/task_e_6898d417fa28832b8b7358e24b8edde4