### PR TITLE
feat: account for device safe areas in footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -254,6 +254,7 @@ li {
   width: 100%;
   text-align: center;
   padding: var(--space-sm) 0;
+  padding-bottom: env(safe-area-inset-bottom);
   background: var(--clr-background);
   color: var(--clr-text);
   font-size: 0.9rem;

--- a/tests/footer.test.js
+++ b/tests/footer.test.js
@@ -63,3 +63,13 @@ test('footer text updates on language toggle', () => {
   updateContent();
   assert.strictEqual(footer.textContent.trim(), translations.es['footer-copyright']);
 });
+
+test('footer uses safe-area padding', () => {
+  const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
+  const footerRule = css.match(/\.ops-footer\s*{[^}]*}/);
+  assert.ok(footerRule, 'ops-footer rule missing');
+  assert.match(
+    footerRule[0],
+    /padding-bottom:\s*env\(\s*safe-area-inset-bottom\s*\)/
+  );
+});


### PR DESCRIPTION
## Summary
- ensure footer respects mobile safe areas with `env(safe-area-inset-bottom)`
- add regression test verifying footer safe-area padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d4190b14832ba40bc98937f019de