### PR TITLE
Fix mobile toggle placement on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -643,10 +643,6 @@ body.dark .ops-modal {
     padding: 0 15px;
     max-width: 100%;
   }
-  .toggles {
-    position: static;
-    margin-top: var(--space-sm);
-  }
 }
 
 @media (max-width: 500px) {
@@ -666,6 +662,9 @@ body.dark .ops-modal {
 @media (max-width: 768px) {
   /* When the viewport is narrow the nav may overflow horizontally;
      enable horizontal scrolling so the controls remain reachable. */
+  body {
+    padding-bottom: calc(var(--space-lg) * 4 + var(--space-sm)); /* extra space for fixed toggles */
+  }
   .ops-nav {
     flex-direction: row;
     justify-content: space-between;
@@ -692,14 +691,6 @@ body.dark .ops-modal {
   .contact-form-section {
     padding: 0 15px;
     max-width: 100%;
-  }
-
-  .toggles {
-    flex-direction: row;
-    position: static;
-    margin-bottom: 0;
-    align-items: center;
-    align-self: auto;
   }
 
   .nav-links {
@@ -752,6 +743,16 @@ body.dark .ops-modal {
 
   .nav-backdrop.open {
     display: block;
+  }
+
+  .toggles {
+    position: fixed;
+    bottom: var(--space-sm);  /* 10px bottom margin */
+    right: var(--space-sm);   /* 10px right margin */
+    flex-direction: column;
+    align-items: flex-end;
+    gap: var(--space-sm);     /* consistent 10px spacing */
+    z-index: 1000;
   }
 }
 

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -18,12 +18,13 @@ test('fab container fixed to viewport corner', () => {
   assert.ok(/right:\s*15px/.test(block), 'fab container should be 15px from right');
 });
 
-test('nav toggles align with fab right margin', () => {
+test('nav toggles align with fab margins', () => {
   const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
-  const match = css.match(/\.toggles\s*{[\s\S]*?}/);
-  assert.ok(match, 'toggles styles not found');
+  const match = css.match(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.toggles\s*{[\s\S]*?}/);
+  assert.ok(match, 'mobile toggles styles not found');
   const block = match[0];
   assert.ok(/right:\s*var\(--space-sm\)/.test(block), 'toggles should use space-sm variable for right positioning');
+  assert.ok(/bottom:\s*var\(--space-sm\)/.test(block), 'toggles should use space-sm variable for bottom positioning');
 });
 
 // Ensure clicking outside or on backdrop closes mobile menu


### PR DESCRIPTION
## Summary
- stack language/theme toggles above the hamburger menu with fixed bottom-right positioning
- add mobile bottom padding to avoid overlap with fixed toggle group
- test for bottom spacing on the toggles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f7b9e870832b8cff8bb0b99399a6