### PR TITLE
Allow modal loading under file protocol and add tests

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -132,8 +132,16 @@ document.addEventListener('DOMContentLoaded', () => {
         const url = `fabs/${modalId}.html`;
         const response = await fetch(url, { credentials: 'same-origin' });
         const responseURL = response.url || '';
-        if (responseURL && !responseURL.startsWith(window.location.origin)) {
-          throw new Error('Cross-origin fetch blocked');
+        if (responseURL && typeof window !== 'undefined' && window.location) {
+          const currentOrigin = window.location.origin;
+          try {
+            const resOrigin = new URL(responseURL, window.location.href).origin;
+            if (currentOrigin && currentOrigin !== 'null' && resOrigin !== currentOrigin) {
+              throw new Error('Cross-origin fetch blocked');
+            }
+          } catch (err) {
+            console.error('URL parsing error:', err);
+          }
         }
         const type = (response.headers && response.headers.get
           ? response.headers.get('Content-Type')

--- a/tests/fab-modals.test.js
+++ b/tests/fab-modals.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+function loadScript(window, file) {
+  const scriptEl = window.document.createElement('script');
+  scriptEl.textContent = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+  window.document.body.appendChild(scriptEl);
+}
+
+test('contact and join modals load under file protocol', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'file:///index.html',
+    runScripts: 'dangerously'
+  });
+  const { window } = dom;
+  const { document } = window;
+
+  window.initCojoinForms = () => {};
+  window.initDraggableModal = () => {};
+
+  window.fetch = async (url) => {
+    const content = url.includes('contact')
+      ? '<div class="modal-container"><button class="modal-close"></button></div>'
+      : '<div class="modal-container"><button class="modal-close"></button></div>';
+    return {
+      url: `file:///fabs/${url.includes('contact') ? 'contact' : 'join'}.html`,
+      headers: { get: () => 'text/html' },
+      text: async () => content
+    };
+  };
+
+  loadScript(window, 'cojoinlistener.js');
+  await new Promise(r => setImmediate(r));
+  document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+  const contactFab = document.getElementById('fab-contact');
+  contactFab.dispatchEvent(new window.Event('click'));
+  await new Promise(r => setImmediate(r));
+  assert.ok(document.getElementById('contact-modal'));
+
+  const joinFab = document.getElementById('fab-join');
+  joinFab.dispatchEvent(new window.Event('click'));
+  await new Promise(r => setImmediate(r));
+  assert.ok(document.getElementById('join-modal'));
+});


### PR DESCRIPTION
## Summary
- Permit Contact/Join/Chatbot modal fetches when served over the `file:` protocol by relaxing cross-origin checks
- Add regression tests ensuring modals open correctly even in offline file deployments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689904406048832b9594d809797ad312