### PR TITLE
fix mobile nav layering and spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,7 @@
   --clr-text-subtle: #333;
   --clr-text-light: #444;
   --clr-background: #fff;
+  --clr-background-rgb: 255, 255, 255;
   --clr-card-bg: rgba(255, 255, 255, 0.77);
   --clr-form-bg: rgba(255, 255, 255, 0.1);
   --clr-form-input-bg: #f5f5f7;
@@ -44,6 +45,7 @@ body.dark {
   --clr-text-subtle: #f3ecfe;
   --clr-text-light: #ccc;
   --clr-background: #121212;
+  --clr-background-rgb: 18, 18, 18;
   --clr-card-bg: rgba(32, 26, 49, 0.91);
   --clr-form-bg: rgba(255, 255, 255, 0.1);
   --clr-form-input-bg: rgba(255, 255, 255, 0.1);
@@ -175,7 +177,7 @@ li {
   text-shadow: 0 0 8px var(--clr-logo-shadow);
   user-select: none;
   position: absolute;
-  left: 2rem;
+  left: var(--space-sm);
 }
 
 .nav-links {
@@ -677,6 +679,7 @@ body.dark .ops-modal {
     position: static;
     left: auto;
     flex-shrink: 0;
+    margin-left: var(--space-sm);
   }
 
   h1 {
@@ -703,17 +706,19 @@ body.dark .ops-modal {
     display: flex;
     flex-direction: column;
     margin-top: 0;
-    background: var(--clr-background);
+    background: rgba(var(--clr-background-rgb), 0.85);
     border-left: 1px solid var(--clr-form-border);
     border-radius: 5px 0 0 5px;
     transform: translateX(100%);
     transition: transform 0.3s ease;
     padding: var(--space-xl) var(--space-md);
-    z-index: 1000;
+    z-index: 900;
+    pointer-events: none;
   }
 
   .nav-links.open {
     transform: translateX(0);
+    pointer-events: auto;
   }
 
   .nav-link {
@@ -738,7 +743,7 @@ body.dark .ops-modal {
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
-    z-index: 999;
+    z-index: 800;
   }
 
   .nav-backdrop.open {

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -29,6 +29,8 @@ test('mobile nav links use off-canvas layout', () => {
   assert.ok(navLinks.includes('right: 0'), 'nav links should align to the right');
   assert.ok(navLinks.includes('transform: translateX(100%)'), 'nav links should be translated off screen');
   assert.ok(navLinks.includes('transition: transform 0.3s'), 'nav links should animate when toggled');
+  assert.ok(navLinks.includes('background: rgba(var(--clr-background-rgb), 0.85)'), 'nav links should have semi-transparent background');
+  assert.ok(navLinks.includes('z-index: 900'), 'nav links should sit below toggles');
 
   const openMatch = css.match(/@media \(max-width: 768px\)[\s\S]*?\.nav-links\.open\s*{[\s\S]*?transform: translateX\(0\)[^}]*}/);
   assert.ok(openMatch, 'nav links should slide in when open');


### PR DESCRIPTION
## Summary
- Align OPS logo 10px from left edge across layouts
- Layer mobile nav panel beneath toggles with 85% opaque background
- Add regression test for nav panel layering and transparency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e5d08b38832b8623438758fc909a