### PR TITLE
fix: keep chatbot modal open after message send

### DIFF
--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -98,9 +98,6 @@ function initChatbot() {
         log.lastChild.textContent = 'Error: Can’t reach AI.';
       }
       send.disabled = false;
-      if (window.hideActiveFabModal) {
-        window.hideActiveFabModal();
-      }
     };
   }
 }

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -272,11 +272,13 @@ test('chatbot modal initializes and handlers work', async () => {
   // Test chat submit
   const form = document.getElementById('chatbot-input-row');
   const log = document.getElementById('chat-log');
+  const container = document.getElementById('chatbot-container');
   input.value = 'Hi';
   await form.onsubmit({ preventDefault() {} });
   assert.strictEqual(log.children.length, 2);
   assert.strictEqual(log.children[0].textContent, 'Hi');
   assert.strictEqual(log.children[1].textContent, 'hello');
+  assert.strictEqual(container.style.display, 'flex');
   assert.ok(!send.disabled);
 
   // Close the modal via the close button and ensure focus returns to the FAB


### PR DESCRIPTION
## Summary
- stop auto-closing the chatbot after submitting a message
- test that the chatbot modal stays visible after sending a message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68990c4bd204832bb3aa3377318632e3