### PR TITLE
Stack chatbot controls vertically

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -17,12 +17,10 @@
     <form id="chatbot-input-row" autocomplete="off">
       <input id="chatbot-input" type="text" placeholder="Type your message..." required maxlength="256"
              data-en-ph="Type your message..." data-es-ph="Escriba su mensaje...">
-      <button id="chatbot-send" type="submit" aria-label="Send">
-        <i class="fas fa-arrow-right"></i>
-      </button>
-      <button id="chatbot-close" type="button" class="modal-close" aria-label="Close">
-        <i class="fas fa-times"></i>
-      </button>
+      <div id="chatbot-controls">
+        <button id="chatbot-send" type="submit" aria-label="Send"><i class="fas fa-arrow-right"></i></button>
+        <button id="chatbot-close" type="button" class="modal-close" aria-label="Close"><i class="fas fa-times"></i></button>
+      </div>
     </form>
    </div>
 </div>

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -63,6 +63,11 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 .bot {margin-right:auto;background:#321b53;color:#fff;padding:.5rem .7rem;border-radius:14px 14px 14px 0}
 #chatbot-form-container{background:#220f3a;border-top:1px solid var(--clr-accent);padding:.55rem .7rem}
 #chatbot-input-row{display:flex;gap:.6rem;align-items:center}
+#chatbot-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
 #chatbot-input{flex:1;background:transparent;border:none;color:#000;font-size:.95rem;padding:.55rem .6rem}
 #chatbot-input::placeholder{color:#000}
 #chatbot-send, #chatbot-close{
@@ -81,8 +86,6 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   padding:0;
 }
 
-#chatbot-send{order:1;margin-left:auto}
 #chatbot-send i,#chatbot-close i{font-size:20px;transition:transform .3s}
 #chatbot-send:hover i{transform:rotate(-45deg)}
 #chatbot-send:disabled{background:#555;cursor:not-allowed}
-#chatbot-close{order:2}


### PR DESCRIPTION
## Summary
- group chatbot send and close buttons into a new container
- flex column layout to stack chatbot controls vertically and simplify button order

## Testing
- `npm test` *(fails: AssertionError in chatbot modal initializes and handlers work)*

------
https://chatgpt.com/codex/tasks/task_e_6899186c16d8832bbdcd7eac19cc8961