### PR TITLE
Fix Chattia control alignment

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -68,6 +68,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  margin-left: auto;
 }
 #chatbot-input{flex:1;background:transparent;border:none;color:#000;font-size:.95rem;padding:.55rem .6rem}
 #chatbot-input::placeholder{color:#000}


### PR DESCRIPTION
## Summary
- Keep chatbot send and close buttons stacked but now flush to the form's right edge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899180e3e4c832b9f48d0403de1f791