### PR TITLE
Adjust chatbot size for mobile and tablet screens

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -41,14 +41,14 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   cursor: move;
 }
 #chatbot-header #title{color:#000;}
-@media (max-width: 767px) {
+@media (max-width: 1024px) {
   #chatbot-container {
-    width: 100%;
-    height: 100%;
-    border-radius: 0;
-    top: 0;
-    left: 0;
-    transform: none;
+    width: 50vw;
+    height: 35vh;
+    border-radius: 18px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     overflow-y: auto;
   }
   #chatbot-header {


### PR DESCRIPTION
## Summary
- Shrink Chattia chatbot to 50% viewport width and 35% viewport height on screens up to 1024px

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68992719d3d8832bb584106df7328700