### PR TITLE
Fix chatbot textarea flex sizing

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -70,7 +70,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   gap: 0.25rem;
   margin-left: auto;
 }
-#chatbot-input{flex:1;background:transparent;border:none;color:#000;font-size:.95rem;padding:.55rem .6rem;min-height:4.5rem;resize:none;width:calc(100% - 2.6rem)}
+#chatbot-input{flex:1;background:transparent;border:none;color:#000;font-size:.95rem;padding:.55rem .6rem;min-height:4.5rem;resize:none}
 #chatbot-input::placeholder{color:#000}
 #chatbot-send, #chatbot-close{
   display:flex;

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -261,6 +261,14 @@ test('chatbot modal initializes and handlers work', async () => {
 
   const input = document.getElementById('chatbot-input');
   assert.strictEqual(document.activeElement, input, 'focus moved to input');
+  assert.strictEqual(input.tagName, 'TEXTAREA', 'chatbot input is a textarea');
+  assert.strictEqual(input.getAttribute('rows'), '4');
+
+  const send = document.getElementById('chatbot-send');
+  const controls = document.getElementById('chatbot-controls');
+  assert.ok(controls, 'controls container present');
+  assert.strictEqual(controls.children[0], send, 'send button present in controls');
+  assert.strictEqual(controls.children[1], closeBtn, 'close button present in controls');
 
   // Test language toggle
   const langCtrl = document.getElementById('langCtrl');
@@ -274,7 +282,6 @@ test('chatbot modal initializes and handlers work', async () => {
   assert.ok(document.body.classList.contains('dark'));
 
   // Send button should be enabled by default
-  const send = document.getElementById('chatbot-send');
   assert.ok(!send.disabled);
 
   // Test chat submit


### PR DESCRIPTION
## Summary
- let chatbot textarea flex to available width by dropping fixed calc-width
- add test coverage for chatbot textarea and control buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7795c120832ba8ff33710aeeca75