### PR TITLE
feat: offset mobile nav under header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -38,7 +38,7 @@
   --space-3xl: 60px;
 
   /* Layout */
-  --ops-nav-height: 75px; /* height of sticky ops-nav bar */
+  --nav-header-height: 85px; /* height of sticky nav header */
 }
 
 /* Dark Theme Variables */
@@ -701,9 +701,9 @@ body.dark .ops-modal {
 
   .nav-links {
     position: fixed;
-    top: var(--ops-nav-height); /* offset below ops-nav */
+    top: var(--nav-header-height); /* offset below nav header */
     right: 0;
-    height: calc(100% - var(--ops-nav-height)); /* fill remaining viewport */
+    height: calc(100% - var(--nav-header-height)); /* fill remaining viewport */
     width: 70%;
     max-width: 300px;
     display: flex;

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -31,6 +31,14 @@ test('mobile nav links use off-canvas layout', () => {
   assert.ok(navLinks.includes('transition: transform 0.3s'), 'nav links should animate when toggled');
   assert.ok(navLinks.includes('background: rgba(var(--clr-background-rgb), 0.85)'), 'nav links should have semi-transparent background');
   assert.ok(navLinks.includes('z-index: 900'), 'nav links should sit below toggles');
+  assert.ok(
+    navLinks.includes('top: var(--nav-header-height)') || navLinks.includes('top: 85px'),
+    'nav links should offset below header'
+  );
+  assert.ok(
+    navLinks.includes('height: calc(100% - var(--nav-header-height))') || navLinks.includes('height: calc(100% - 85px)'),
+    'nav links should account for header height'
+  );
 
   const openMatch = css.match(/@media \(max-width: 768px\)[\s\S]*?\.nav-links\.open\s*{[\s\S]*?transform: translateX\(0\)[^}]*}/);
   assert.ok(openMatch, 'nav links should slide in when open');


### PR DESCRIPTION
## Summary
- add `--nav-header-height` variable to represent mobile header
- use header height to position mobile nav links below the fixed header
- test for nav link offset and height against header height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af7919e08832b8e8ab60e16f09127