### PR TITLE
Ensure mobile nav toggle overlays FAB

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -737,6 +737,8 @@ body.dark .ops-modal {
     display: block;
     margin: 0;
     align-self: flex-end;
+    position: relative;
+    z-index: 1002;
   }
 
   .nav-backdrop {
@@ -763,7 +765,7 @@ body.dark .ops-modal {
     flex-direction: column;
     align-items: flex-end;
     gap: var(--space-sm);     /* consistent 10px spacing */
-    z-index: 1000;
+    z-index: 1001;
   }
 }
 

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -32,6 +32,13 @@ body {
   gap: 15px;
 }
 
+@media (max-width: 768px) {
+  .fab-container {
+    right: auto;
+    left: 15px;
+  }
+}
+
 .fab-main {
   width: 60px;
   height: 60px;

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -44,6 +44,20 @@ test('ops-nav enables horizontal scrolling when cramped', () => {
   assert.ok(navBlock.includes('overflow-x: auto'), '.ops-nav should allow horizontal scrolling');
 });
 
+test('nav toggle sits above floating action button', () => {
+  const styleCss = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
+  const toggleMatch = styleCss.match(/@media \(max-width: 768px\)[\s\S]*?\.nav-menu-toggle\s*{[\s\S]*?z-index:\s*(\d+)/);
+  assert.ok(toggleMatch, 'nav-menu-toggle z-index missing');
+  const navZ = parseInt(toggleMatch[1], 10);
+
+  const fabCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'cojoin.css'), 'utf-8');
+  const fabMatch = fabCss.match(/\.fab-container\s*{[\s\S]*?z-index:\s*(\d+)/);
+  assert.ok(fabMatch, 'fab-container z-index missing');
+  const fabZ = parseInt(fabMatch[1], 10);
+
+  assert.ok(navZ > fabZ, 'nav toggle should have higher z-index than FAB');
+});
+
 // Verify HTML structure defaults (nav links closed)
 const pages = ['index.html', 'contact-center.html', 'it-support.html', 'professional-services.html'];
 for (const page of pages) {


### PR DESCRIPTION
## Summary
- Raise mobile menu toggle and control group to a higher z-index so the button stays above other UI elements.
- Reposition the floating action button on small screens to avoid the nav toggle while keeping FAB functionality.
- Add regression test verifying the nav toggle sits above the FAB.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af7a2f794832b92c5a06f9256df6a