### PR TITLE
Align chatbot input with control buttons

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -70,7 +70,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   gap: 0.25rem;
   margin-left: auto;
 }
-#chatbot-input{flex:1;background:transparent;border:none;color:#000;font-size:.95rem;padding:.55rem .6rem;min-height:calc(4.5rem - 5px);margin-top:5px;resize:none}
+#chatbot-input{flex:1;background:transparent;border:none;color:#000;font-size:.95rem;padding:.55rem .6rem;min-height:calc(4.5rem - 15px);margin-top:15px;resize:none}
 #chatbot-input::placeholder{color:#000}
 #chatbot-send, #chatbot-close{
   display:flex;


### PR DESCRIPTION
## Summary
- Reduce chatbot input height by 10px and shift it downward to line up with send and close buttons

## Testing
- `npm test` *(fails: Identifier 'nonce' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_689b14c43de4832b90080d279f0044f1