### PR TITLE
Enable Chattia exit control and cleanup listeners

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -19,30 +19,30 @@
 
   <div id="chatbot-form-container">
     <form id="chatbot-input-grid" autocomplete="off">
-      <div id="input-toolbar" aria-label="Ops Online Support">
-        <div id="brand" data-en="Ops Online Support" data-es="Soporte en Línea OPS" title="Ops Online Support"></div>
-      </div>
-      <div id="input-main">
-        <textarea
-          id="chatbot-input"
-          rows="1"
-          placeholder="Type your message..."
-          required
-          maxlength="512"
-          data-en-ph="Type your message..."
-          data-es-ph="Escriba su mensaje..."
-        ></textarea>
-      </div>
-      <div id="button-stack">
-        <button id="chatbot-send" type="submit" class="btn" disabled aria-label="Send">
-          <i class="fa-solid fa-arrow-right"></i>
-        </button>
-        <button id="chatbot-clear" type="button" class="btn secondary" aria-label="Clear">
-          <i class="fa-solid fa-xmark"></i>
-        </button>
-      </div>
-    </form>
-    <label class="human-check">
+        <div id="input-toolbar" aria-label="Ops Online Support">
+          <div id="brand" data-en="Ops Online Support" data-es="Soporte en Línea OPS" title="Ops Online Support"></div>
+        </div>
+        <div id="input-main">
+          <textarea
+            id="chatbot-input"
+            rows="1"
+            placeholder="Type your message..."
+            required
+            maxlength="512"
+            data-en-ph="Type your message..."
+            data-es-ph="Escriba su mensaje..."
+          ></textarea>
+        </div>
+        <div id="button-stack">
+          <button id="chatbot-send" type="submit" class="btn" disabled aria-label="Send">
+            <i class="fa-solid fa-arrow-right"></i>
+          </button>
+          <button id="chatbot-exit" type="button" class="btn secondary" aria-label="Exit chat">
+            <i class="fa-solid fa-xmark"></i>
+          </button>
+        </div>
+      </form>
+      <label class="human-check">
       <input type="checkbox" id="human-check" />
       <span id="human-label" data-en="I am human" data-es="Soy humano">I am human</span>
     </label>

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -1,5 +1,5 @@
 (function(){
-  let langCtrl, themeCtrl, log, form, input, send, clearBtn, guard;
+  let langCtrl, themeCtrl, log, form, input, send, exitBtn, guard;
   let minimizeBtn, openBtn, container, header, inactivityTimer;
   let langHandler, themeHandler, formHandler, guardHandler, minimizeHandler, openHandler;
 
@@ -14,7 +14,7 @@
     form = qs('#chatbot-input-grid');
     input = qs('#chatbot-input');
     send = qs('#chatbot-send');
-    clearBtn = qs('#chatbot-clear');
+    exitBtn = qs('#chatbot-exit');
     guard = qs('#human-check');
     langCtrl = qs('#langCtrl');
     themeCtrl = qs('#themeCtrl');
@@ -99,7 +99,7 @@
       }
     };
     form.addEventListener('submit', formHandler);
-    clearBtn.addEventListener('click', () => { input.value=''; autoGrow(); });
+    if(exitBtn) exitBtn.addEventListener('click', endSession);
 
     function setVHUnit(h){ const vh = h ? (h/100) : (window.innerHeight/100); root.style.setProperty('--vh', vh + 'px'); }
     setVHUnit();
@@ -269,11 +269,12 @@
     if(themeCtrl && themeHandler) themeCtrl.removeEventListener('click', themeHandler);
     if(form && formHandler) form.removeEventListener('submit', formHandler);
     if(guard && guardHandler) guard.removeEventListener('change', guardHandler);
+    if(exitBtn) exitBtn.removeEventListener('click', endSession);
     if(minimizeBtn && minimizeHandler) minimizeBtn.removeEventListener('click', minimizeHandler);
     if(openBtn && openHandler) openBtn.removeEventListener('click', openHandler);
     if(container) container.remove();
     if(openBtn) openBtn.remove();
-    langCtrl=themeCtrl=log=form=input=send=clearBtn=guard=null;
+    langCtrl=themeCtrl=log=form=input=send=exitBtn=guard=null;
     minimizeBtn=openBtn=container=header=null;
     inactivityTimer=null;
   }


### PR DESCRIPTION
## Summary
- wire up Chattia's X button to fully end and hide the chat session
- clean up exit listener during chatbot teardown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dae9ff7e0832baae32b65c7e327eb