### PR TITLE
Fix mobile alignment for Join Us form buttons

### DIFF
--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -246,6 +246,12 @@ input, select, textarea {
   align-items: center;
 }
 
+.section-header > div {
+  display: flex;
+  gap: 0.3rem;
+  flex-shrink: 0;
+}
+
 .circle-btn {
   width: 28px;
   height: 28px;
@@ -257,7 +263,7 @@ input, select, textarea {
   font-size: 1.3rem;
   cursor: pointer;
   user-select: none;
-  margin-left: 0.3rem;
+  margin-left: 0;
 }
 
 .circle-btn.remove {


### PR DESCRIPTION
## Summary
- Ensure the Join Us form's plus and minus buttons stay side-by-side on mobile by using a flex container and preventing shrinking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689db7dcb58c832b9233c010484aa6a4