### PR TITLE
Add invisible reCAPTCHA trap and exit triggers to Chattia

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -34,7 +34,7 @@
           ></textarea>
         </div>
         <div id="button-stack">
-          <button id="chatbot-send" type="submit" class="btn" disabled aria-label="Send">
+          <button id="chatbot-send" type="submit" class="btn" aria-label="Send">
             <i class="fa-solid fa-arrow-right"></i>
           </button>
           <button id="chatbot-exit" type="button" class="btn secondary" aria-label="Exit chat">
@@ -42,9 +42,14 @@
           </button>
         </div>
       </form>
-      <label class="human-check">
-      <input type="checkbox" id="human-check" />
-      <span id="human-label" data-en="I am human" data-es="Soy humano">I am human</span>
-    </label>
+      <!-- Honeypot human check; hidden from real users -->
+      <label class="human-check" style="display:none;">
+        <input type="checkbox" id="human-check" />
+        <span id="human-label" data-en="I am human" data-es="Soy humano">I am human</span>
+      </label>
+      <div id="recaptcha-container" class="g-recaptcha"
+        data-size="invisible"
+        data-sitekey="YOUR_RECAPTCHA_SITE_KEY"><!-- TODO: Insert real reCAPTCHA site key --></div>
+      <script src="https://www.google.com/recaptcha/api.js" async defer></script>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Replace manual human check with hidden reCAPTCHA v2 Invisible trap and placeholder site key
- Allow ESC key and outside clicks to close chatbot, and arrow key submits messages
- Update tests for new exit behaviors and honeypot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e9c2f894c832b8e37368df6167ca9