### PR TITLE
Disable human-trap checkbox in Chattia chatbot

### DIFF
--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -1,7 +1,7 @@
 (function(){
   let langCtrl, themeCtrl, log, form, input, send, exitBtn, guard;
   let minimizeBtn, openBtn, container, header, inactivityTimer, recaptchaId;
-  let langHandler, themeHandler, formHandler, guardHandler, minimizeHandler, openHandler, escHandler, outsideClickHandler;
+  let langHandler, themeHandler, formHandler, minimizeHandler, openHandler, escHandler, outsideClickHandler;
 
   function initChatbot(){
     const qs = s => document.querySelector(s),
@@ -63,14 +63,7 @@
     };
     themeCtrl.addEventListener('click', themeHandler);
 
-    guardHandler = () => {
-      if(window.grecaptcha && typeof window.grecaptcha.execute === 'function' && typeof recaptchaId !== 'undefined'){
-        window.grecaptcha.execute(recaptchaId);
-      }
-      window.alert('Session blocked');
-      endSession();
-    };
-    guard.addEventListener('click', guardHandler);
+    // Honeypot checkbox intentionally inert – it stays hidden and performs no action
 
     function autoGrow(){
       input.style.height='auto';
@@ -298,7 +291,6 @@
     if(langCtrl && langHandler) langCtrl.removeEventListener('click', langHandler);
     if(themeCtrl && themeHandler) themeCtrl.removeEventListener('click', themeHandler);
     if(form && formHandler) form.removeEventListener('submit', formHandler);
-    if(guard && guardHandler) guard.removeEventListener('click', guardHandler);
     if(exitBtn) exitBtn.removeEventListener('click', endSession);
     if(minimizeBtn && minimizeHandler) minimizeBtn.removeEventListener('click', minimizeHandler);
     if(openBtn && openHandler) openBtn.removeEventListener('click', openHandler);

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -151,13 +151,13 @@ test('Chattia chatbot exits on multiple triggers', async () => {
   window1.document.body.appendChild(outside);
   outside.dispatchEvent(new window1.MouseEvent('click', { bubbles: true }));
   assert.strictEqual(window1.document.getElementById('chatbot-container'), null);
-
-  // human trap triggers alert and closes
+  
+  // hidden human-check box remains inert if somehow clicked
   window1 = setup();
   let alerted = false;
   window1.alert = () => { alerted = true; };
   const guard = window1.document.getElementById('human-check');
   guard.dispatchEvent(new window1.MouseEvent('click', { bubbles: true }));
-  assert.ok(alerted);
-  assert.strictEqual(window1.document.getElementById('chatbot-container'), null);
+  assert.strictEqual(alerted, false);
+  assert.notStrictEqual(window1.document.getElementById('chatbot-container'), null);
 });


### PR DESCRIPTION
## Summary
- remove the honeypot checkbox handler so it stays hidden and inert
- adjust chatbot tests for inert human-trap while retaining multiple exit paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ebfa74620832b8ac9dc102ce5c136