### PR TITLE
Harden chatbot exit triggers and remove hidden human-check logic

### DIFF
--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -1,5 +1,5 @@
 (function(){
-  let langCtrl, themeCtrl, log, form, input, send, exitBtn, guard;
+  let langCtrl, themeCtrl, log, form, input, send, exitBtn;
   let minimizeBtn, openBtn, container, header, inactivityTimer, recaptchaId;
   let langHandler, themeHandler, formHandler, minimizeHandler, openHandler, escHandler, outsideClickHandler;
 
@@ -15,7 +15,6 @@
     input = qs('#chatbot-input');
     send = qs('#chatbot-send');
     exitBtn = qs('#chatbot-exit');
-    guard = qs('#human-check');
     langCtrl = qs('#langCtrl');
     themeCtrl = qs('#themeCtrl');
     minimizeBtn = qs('#minimizeBtn');
@@ -238,7 +237,6 @@
     function endSession(){
       clearInactivity();
       log.innerHTML='';
-      guard.checked=false;
       send.disabled=true;
       minimizeChat();
       if(typeof window.hideActiveFabModal === 'function'){
@@ -298,7 +296,7 @@
     document.removeEventListener('click', outsideClickHandler);
     if(container) container.remove();
     if(openBtn) openBtn.remove();
-    langCtrl=themeCtrl=log=form=input=send=exitBtn=guard=null;
+    langCtrl=themeCtrl=log=form=input=send=exitBtn=null;
     minimizeBtn=openBtn=container=header=null;
     escHandler=outsideClickHandler=null;
     inactivityTimer=recaptchaId=null;


### PR DESCRIPTION
## Summary
- Remove all JavaScript logic tied to the hidden "I am human" checkbox honeypot so it remains inert
- Keep chatbot accessible via clean exit flow on X button, ESC key, and outside/backdrop clicks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ee59e8a24832bb31cf818336ca86d