### PR TITLE
fix: preserve minimized chatbot on resize

### DIFF
--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -255,30 +255,38 @@
     });
 
     let isChatVisible=true;
+    function applyChatVisibility(){
+      if(isChatVisible){
+        container.style.display='';
+        container.removeAttribute('aria-hidden');
+        if(openBtn){
+          openBtn.style.display='none';
+          openBtn.setAttribute('aria-expanded','true');
+        }
+      }else{
+        container.style.display='none';
+        container.setAttribute('aria-hidden','true');
+        if(openBtn){
+          openBtn.style.display='inline-flex';
+          openBtn.setAttribute('aria-expanded','false');
+        }
+      }
+    }
     function minimizeChat(){
       isChatVisible=false;
       clearInactivity();
-      container.style.display='none';
-      container.setAttribute('aria-hidden','true');
-      if(openBtn){
-        openBtn.style.display='inline-flex';
-        openBtn.setAttribute('aria-expanded','false');
-      }
+      applyChatVisibility();
     }
     function openChat(){
       isChatVisible=true;
-      container.style.display='';
-      container.removeAttribute('aria-hidden');
-      if(openBtn){
-        openBtn.style.display='none';
-        openBtn.setAttribute('aria-expanded','true');
-      }
       scheduleInactivity();
+      applyChatVisibility();
     }
     minimizeHandler = minimizeChat;
     openHandler = openChat;
     minimizeBtn.addEventListener('click', minimizeHandler);
     if(openBtn) openBtn.addEventListener('click', openHandler);
+    window.addEventListener('resize', applyChatVisibility);
 
     scheduleInactivity();
   }

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -77,6 +77,9 @@ test('Chattia chatbot core interactions', async () => {
   const openBtn = document.getElementById('chat-open-btn');
   minimizeBtn.click();
   assert.strictEqual(containerEl.style.display, 'none');
+  window.innerWidth = 400;
+  window.dispatchEvent(new window.Event('resize'));
+  assert.strictEqual(containerEl.style.display, 'none', 'remains minimized after resize');
   openBtn.click();
   assert.strictEqual(containerEl.style.display, '');
 


### PR DESCRIPTION
## Summary
- ensure Chattia chatbot remains minimized after viewport changes
- test that minimized chatbot stays hidden when screen is resized

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f858bbe2c832b8a1e1b717104f730