### PR TITLE
Fix chatbot viewport height handling

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -34,8 +34,10 @@ body {
   position:fixed;
   left:4vw; right:4vw; bottom:calc(env(safe-area-inset-bottom) + 8px);
   width:auto;
-  height:calc(var(--vh) * 80);
-  max-height:calc(var(--vh) * 85);
+  height:45vh;
+  max-height:45vh;
+  height:45dvh;
+  max-height:45dvh;
   background: var(--panel);
   border:2px solid var(--clr-accent);
   border-radius:18px;
@@ -48,8 +50,10 @@ body {
   #chatbot-container{ width:380px; left:auto; right:24px; bottom:24px; }
 }
 body.kb-open #chatbot-container{
-  height:calc(var(--vh) * 62);
-  max-height:calc(var(--vh) * 65);
+  height:45vh;
+  max-height:45vh;
+  height:45dvh;
+  max-height:45dvh;
 }
 #chat-open-btn{
   position:fixed; right:20px; bottom:20px;

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -145,16 +145,13 @@
       if(isOpen){ setTimeout(()=> input.scrollIntoView({ block:'nearest', behavior:'smooth' }), 50); }
     }
     function handleViewportChange(){
+      setVHUnit();
       const vv = window.visualViewport;
-      if(vv){
-        setVHUnit(vv.height);
-        const keyboardLikelyOpen = inputFocused && (vv.height < window.innerHeight * 0.85);
-        applyKeyboardMode(keyboardLikelyOpen);
-      }else{
-        setVHUnit();
-        const keyboardLikelyOpen = inputFocused && (window.innerHeight < screen.height * 0.85);
-        applyKeyboardMode(keyboardLikelyOpen);
-      }
+      const keyboardLikelyOpen = inputFocused && (
+        vv ? (vv.height < window.innerHeight * 0.85)
+           : (window.innerHeight < screen.height * 0.85)
+      );
+      applyKeyboardMode(keyboardLikelyOpen);
     }
     let rAF; function onResize(){ cancelAnimationFrame(rAF); rAF = requestAnimationFrame(handleViewportChange); }
     if(window.visualViewport){


### PR DESCRIPTION
## Summary
- Force chatbot container to use a constant 45dvh height regardless of keyboard state
- Simplify viewport logic so kb-open no longer affects container height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f93c14c8c832b8bea84f3bae6dcb9