### PR TITLE
Make chatbot container full-width on mobile

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -10,7 +10,6 @@
   --input-bg:   #f5f2fa;
   --input-bd:   #cbb3f6;
   --text-inv:   #ffffff;
-  --vh: 1vh;
 }
 body.dark {
   --bg:       #121212;
@@ -32,10 +31,12 @@ body {
 }
 #chatbot-container{
   position:fixed;
-  left:4vw; right:4vw; bottom:calc(env(safe-area-inset-bottom) + 8px);
-  width:auto;
-  height:calc(var(--vh) * 80);
-  max-height:calc(var(--vh) * 85);
+  left:0; right:0; bottom:calc(env(safe-area-inset-bottom) + 8px);
+  width:100%;
+  height:80vh;
+  height:80dvh;
+  max-height:85vh;
+  max-height:85dvh;
   background: var(--panel);
   border:2px solid var(--clr-accent);
   border-radius:18px;
@@ -48,8 +49,10 @@ body {
   #chatbot-container{ width:380px; left:auto; right:24px; bottom:24px; }
 }
 body.kb-open #chatbot-container{
-  height:calc(var(--vh) * 62);
-  max-height:calc(var(--vh) * 65);
+  height:62vh;
+  height:62dvh;
+  max-height:65vh;
+  max-height:65dvh;
 }
 #chat-open-btn{
   position:fixed; right:20px; bottom:20px;
@@ -138,9 +141,4 @@ body.dark #chatbot-input{ color:#efeaf8; }
 .btn.secondary{ background:#ff66e7; }
 .human-check{ display:none!important; }
 .human-check input{ margin-right:.4rem }
-@media(max-width:480px){
-  #chatbot-container{ left:3vw; right:3vw; }
-}
-@supports (height: 100dvh){ :root{ --vh: 1dvh; } }
-@supports (height: 100svh){ :root{ --vh: 1svh; } }
 

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -6,7 +6,6 @@
   function initChatbot(){
     const qs = s => document.querySelector(s),
           qsa = s => [...document.querySelectorAll(s)];
-    const root = document.documentElement;
     container = qs('#chatbot-container');
     if (!container) return;
     header = qs('#chatbot-header');
@@ -137,8 +136,6 @@
     };
     document.addEventListener('click', outsideClickHandler);
 
-    function setVHUnit(h){ const vh = h ? (h/100) : (window.innerHeight/100); root.style.setProperty('--vh', vh + 'px'); }
-    setVHUnit();
     let inputFocused=false;
     function applyKeyboardMode(isOpen){
       document.body.classList.toggle('kb-open', !!isOpen);
@@ -147,11 +144,9 @@
     function handleViewportChange(){
       const vv = window.visualViewport;
       if(vv){
-        setVHUnit(vv.height);
         const keyboardLikelyOpen = inputFocused && (vv.height < window.innerHeight * 0.85);
         applyKeyboardMode(keyboardLikelyOpen);
       }else{
-        setVHUnit();
         const keyboardLikelyOpen = inputFocused && (window.innerHeight < screen.height * 0.85);
         applyKeyboardMode(keyboardLikelyOpen);
       }
@@ -162,9 +157,9 @@
       visualViewport.addEventListener('scroll', onResize);
     }
     window.addEventListener('resize', onResize);
-    window.addEventListener('orientationchange', ()=>{ setTimeout(()=>{ setVHUnit(); handleViewportChange(); }, 100); });
+    window.addEventListener('orientationchange', ()=>{ setTimeout(()=>{ handleViewportChange(); }, 100); });
     input.addEventListener('focus', ()=>{ inputFocused=true; handleViewportChange(); });
-    input.addEventListener('blur', ()=>{ inputFocused=false; applyKeyboardMode(false); setVHUnit(); });
+    input.addEventListener('blur', ()=>{ inputFocused=false; applyKeyboardMode(false); });
 
     const DRAG_MIN_WIDTH=900;
     let dragActive=false, dragStart={x:0,y:0}, boxStart={x:0,y:0};


### PR DESCRIPTION
## Summary
- Expand chatbot container to full width on small screens by setting left/right to 0 and width to 100%
- Use `dvh` units with `vh` fallbacks for chatbot height and remove manual viewport handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f93c3c298832ba94fd80a4c3cf1e8