### PR TITLE
Persist chatbot history across pages

### DIFF
--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -39,12 +39,32 @@
     }
   }
 
+  function saveHistory(){
+    if(!log) return;
+    const msgs=[...log.querySelectorAll('.chat-msg')].map(m=>({
+      cls:m.className.replace('chat-msg ','').trim(),
+      text:m.textContent
+    }));
+    try{ sessionStorage.setItem('chatHistory', JSON.stringify(msgs)); }catch(e){}
+  }
+
+  function loadHistory(){
+    let msgs=[];
+    try{ msgs = JSON.parse(sessionStorage.getItem('chatHistory')||'[]'); }catch(e){ msgs=[]; }
+    msgs.forEach(m=>addMsg(m.text, m.cls));
+  }
+
+  function clearHistory(){
+    try{ sessionStorage.removeItem('chatHistory'); }catch(e){}
+  }
+
   function addMsg(txt, cls){
     const div=document.createElement('div');
     div.className='chat-msg '+cls;
     div.textContent=txt;
     log.appendChild(div);
     log.scrollTop=log.scrollHeight;
+    saveHistory();
   }
 
   async function reportHoneypot(reason){
@@ -102,8 +122,10 @@
       });
       const d = await r.json();
       log.lastChild.textContent = d.reply || 'No reply.';
+      saveHistory();
     }catch{
       log.lastChild.textContent = 'Error: Can’t reach AI.';
+      saveHistory();
     }
   }
 
@@ -116,6 +138,7 @@
     input.value='';
     autoGrow();
     updateSendEnabled();
+    clearHistory();
   }
 
   function openChat(){
@@ -194,6 +217,7 @@
       hpCheck.addEventListener(ev, ()=>{ reportHoneypot('hp_check_ticked'); lockUIForHoneypot(); }, { passive:true });
     });
 
+    loadHistory();
     loadRecaptcha();
   }
 
@@ -213,5 +237,6 @@
 
   window.reloadChat = reloadChat;
   window.initChatbot = initChatbot;
+  window.cleanupChatbot = closeChat;
   window.addEventListener('load', reloadChat);
 })();


### PR DESCRIPTION
## Summary
- Persist chat messages in sessionStorage so conversations continue across site tabs
- Clear stored history and terminate chat session when users close the chatbot
- Test chat history persistence and cleanup behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fc02a53d0832b890235d4ac2af0a3