### PR TITLE
feat: improve chatbot open/close behavior

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -124,7 +124,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let modal = document.getElementById(targetId);
     if (modal) {
-      modal.style.display = 'flex';
+      if (modalId === 'chatbot') {
+        if (window.openChatbot) { window.openChatbot(); }
+      } else {
+        modal.style.display = 'flex';
+      }
       activeModal = modal;
     } else {
       // Dynamic loading logic: fetch HTML from 'fabs/' directory
@@ -177,18 +181,18 @@ document.addEventListener('DOMContentLoaded', () => {
               console.error('initCojoinForms failed:', err);
             }
           }
-          modal.style.display = 'flex';
+          if (modalId === 'chatbot') {
+            if (window.initChatbot) { window.initChatbot(); }
+            if (window.openChatbot) { window.openChatbot(); }
+          } else {
+            modal.style.display = 'flex';
+          }
           activeModal = modal;
 
           // Add close button functionality
           const closeBtn = modal.querySelector('.modal-close');
-          // For chatbot, the close button is part of the header, but we can still target it if needed
           if (closeBtn) {
             closeBtn.addEventListener('click', () => hideModal(modal));
-          }
-
-          if (modalId === 'chatbot' && window.initChatbot) {
-            window.initChatbot();
           }
         }
       } catch (error) {
@@ -198,10 +202,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (modal) {
       removeOverlay();
-      overlay = document.createElement('div');
-      overlay.className = 'modal-overlay';
-      overlay.addEventListener('click', () => hideModal(modal));
-      document.body.appendChild(overlay);
+      if (modalId !== 'chatbot') {
+        overlay = document.createElement('div');
+        overlay.className = 'modal-overlay';
+        overlay.addEventListener('click', () => hideModal(modal));
+        document.body.appendChild(overlay);
+      }
 
       // Initialize draggable on window load, then update on resize
       // This function is expected to be defined in fabs/js/cojoin.js

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -169,7 +169,7 @@
     openBtn.style.display='inline-flex';
     openBtn.setAttribute('aria-expanded','false');
     openBtn.removeEventListener('click', openChat);
-    openBtn.addEventListener('click', ()=>{ reloadChat(); }, { once:true });
+    openBtn.addEventListener('click', reloadChat, { once:true });
   }
 
   function initChatbot(){
@@ -239,6 +239,13 @@
       hpCheck.addEventListener(ev, ()=>{ reportHoneypot('hp_check_ticked'); lockUIForHoneypot(); }, { passive:true });
     });
 
+    // Start with chat hidden until the user explicitly opens it.
+    container.style.display = 'none';
+    container.setAttribute('aria-hidden', 'true');
+    openBtn.style.display = 'inline-flex';
+    openBtn.setAttribute('aria-expanded', 'false');
+    openBtn.addEventListener('click', openChat, { once: true });
+
     loadHistory();
     loadRecaptcha();
   }
@@ -260,5 +267,6 @@
   window.reloadChat = reloadChat;
   window.initChatbot = initChatbot;
   window.cleanupChatbot = closeChat;
+  window.openChatbot = openChat;
   window.addEventListener('load', reloadChat);
 })();

--- a/tests/chatbot-close-behavior.test.js
+++ b/tests/chatbot-close-behavior.test.js
@@ -40,6 +40,7 @@ test('Chattia closes on outside click and ESC key', async () => {
   window.eval(dragScript);
   window.eval(script);
   await window.reloadChat();
+  window.openChatbot();
 
   // outside click closes
   document.body.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
@@ -47,6 +48,7 @@ test('Chattia closes on outside click and ESC key', async () => {
 
   // reload and test ESC key
   await window.reloadChat();
+  window.openChatbot();
   assert.ok(document.getElementById('chatbot-container'));
   document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
   assert.strictEqual(document.getElementById('chatbot-container'), null);


### PR DESCRIPTION
## Summary
- load chatbot hidden and open it on demand
- ensure closing the chat clears session data
- drop modal overlay for chatbot windows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fc590f3f8832b98d850cf8dac6a45