### PR TITLE
Center chatbot modal and add inactivity auto-close

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -2,7 +2,7 @@
 <button id="chat-open-btn" aria-label="Open chat">
   <i class="fa-solid fa-comments"></i>
 </button>
-<div id="chatbot-container" role="dialog" aria-modal="true" aria-label="Chattia">
+<div id="chatbot-container" role="dialog" aria-modal="true" aria-label="Chattia" style="display:none" aria-hidden="true">
   <div id="chatbot-header">
     <span id="title" data-en="Chattia" data-es="Chattia">Chattia</span>
     <div>

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -31,8 +31,11 @@ body {
 }
 #chatbot-container{
   position:fixed;
-   left:2vw; right:2vw; bottom:calc(env(safe-area-inset-bottom) + 8px);
-  width:100%;
+  top:50%;
+  left:50%;
+  transform:translate(-50%, -50%);
+  width:90vw;
+  max-width:380px;
   height:80vh;
   height:80dvh;
   max-height:85vh;
@@ -46,7 +49,7 @@ body {
   z-index:9999;
 }
 @media (min-width: 900px){
-  #chatbot-container{ width:380px; left:auto; right:24px; bottom:24px; }
+  #chatbot-container{ width:380px; }
 }
 body.kb-open #chatbot-container{
   height:62vh;

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -7,7 +7,12 @@
   let container, log, form, input, send, closeBtn, minimizeBtn, openBtn;
   let langCtrl, themeCtrl, brand, hpText, hpCheck;
   let recaptchaReady = false;
-  let outsideClickHandler, escKeyHandler;
+  let outsideClickHandler, escKeyHandler, inactivityTimer;
+
+  function resetInactivityTimer(){
+    clearTimeout(inactivityTimer);
+    inactivityTimer = setTimeout(()=>{ closeChat(); }, 120000);
+  }
 
   function loadRecaptcha(){
     if(document.getElementById('recaptcha-script')) return;
@@ -143,6 +148,7 @@
   }
 
   function openChat(){
+    clearTimeout(inactivityTimer);
     container.style.display='';
     container.removeAttribute('aria-hidden');
     openBtn.style.display='none';
@@ -158,9 +164,11 @@
     openBtn.setAttribute('aria-expanded','false');
     openBtn.removeEventListener('click', reloadChat);
     openBtn.addEventListener('click', openChat, { once:true });
+    resetInactivityTimer();
   }
 
   function closeChat(){
+    clearTimeout(inactivityTimer);
     clearUIState();
     terminateSession();
     document.removeEventListener('click', outsideClickHandler);
@@ -245,6 +253,7 @@
 
   async function reloadChat(){
     try{
+      document.querySelectorAll('#chatbot-container, #chat-open-btn').forEach(el=>el.remove());
       const res = await fetch('fabs/chatbot.html', { credentials:'same-origin' });
       const html = await res.text();
       const template = document.createElement('template');
@@ -252,6 +261,7 @@
       const frag = template.content;
       document.body.appendChild(frag);
       initChatbot();
+      minimizeChat();
     }catch(err){
       console.error('Failed to reload chatbot:', err);
     }

--- a/tests/chatbot-close-behavior.test.js
+++ b/tests/chatbot-close-behavior.test.js
@@ -40,6 +40,7 @@ test('Chattia closes on outside click and ESC key', async () => {
   window.eval(dragScript);
   window.eval(script);
   await window.reloadChat();
+  document.getElementById('chat-open-btn').click();
 
   // outside click closes
   document.body.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
@@ -47,6 +48,7 @@ test('Chattia closes on outside click and ESC key', async () => {
 
   // reload and test ESC key
   await window.reloadChat();
+  document.getElementById('chat-open-btn').click();
   assert.ok(document.getElementById('chatbot-container'));
   document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
   assert.strictEqual(document.getElementById('chatbot-container'), null);

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -36,6 +36,7 @@ test('Chattia chatbot basic interactions', async () => {
   window.eval(dragScript);
   window.eval(script);
   await window.reloadChat();
+  document.getElementById('chat-open-btn').click();
   const brand = document.getElementById('brand');
   assert.ok(brand.querySelectorAll('.char').length > 0);
   const langCtrl = document.getElementById('langCtrl');
@@ -67,6 +68,7 @@ test('Chattia chatbot basic interactions', async () => {
   document.querySelectorAll('#chat-open-btn').forEach(el => el.remove());
   window.sessionStorage.clear();
   await window.reloadChat();
+  document.getElementById('chat-open-btn').click();
   const minimizeBtn = document.getElementById('minimizeBtn');
   const container = document.getElementById('chatbot-container');
   const openBtn = document.getElementById('chat-open-btn');
@@ -99,6 +101,7 @@ test('Chattia chatbot basic interactions', async () => {
   document.querySelectorAll('#chatbot-container').forEach(el => el.remove());
   document.querySelectorAll('#chat-open-btn').forEach(el => el.remove());
   await window.reloadChat();
+  document.getElementById('chat-open-btn').click();
   const logText = document.getElementById('chat-log').textContent;
   assert.ok(logText.includes('Hello'));
   const closeBtn = document.getElementById('chatbot-close');


### PR DESCRIPTION
## Summary
- Center chatbot modal on screen and hide by default
- Start inactivity timer that closes session 2 minutes after minimizing
- Update tests to account for new open workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fc6e1ea30832b908166c8691cca3b