### PR TITLE
Refine chatbot minimize and close behavior

### DIFF
--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -153,7 +153,6 @@
     container.removeAttribute('aria-hidden');
     openBtn.style.display='none';
     openBtn.setAttribute('aria-expanded','true');
-    openBtn.removeEventListener('click', reloadChat);
     openBtn.removeEventListener('click', openChat);
   }
 
@@ -162,7 +161,6 @@
     container.setAttribute('aria-hidden','true');
     openBtn.style.display='inline-flex';
     openBtn.setAttribute('aria-expanded','false');
-    openBtn.removeEventListener('click', reloadChat);
     openBtn.addEventListener('click', openChat, { once:true });
     resetInactivityTimer();
   }
@@ -174,10 +172,10 @@
     document.removeEventListener('click', outsideClickHandler);
     document.removeEventListener('keydown', escKeyHandler);
     container.remove();
-    openBtn.style.display='inline-flex';
-    openBtn.setAttribute('aria-expanded','false');
-    openBtn.removeEventListener('click', openChat);
-    openBtn.addEventListener('click', reloadChat, { once:true });
+    if (openBtn && openBtn.remove) {
+      openBtn.remove();
+    }
+    openBtn = null;
   }
 
   function initChatbot(){
@@ -236,7 +234,7 @@
         !container.contains(e.target) &&
         e.target !== openBtn
       ){
-        closeChat();
+        minimizeChat();
       }
     };
     document.addEventListener('keydown', escKeyHandler);
@@ -278,5 +276,4 @@
   window.initChatbot = initChatbot;
   window.cleanupChatbot = closeChat;
   window.openChatbot = openChat;
-  window.addEventListener('load', reloadChat);
 })();

--- a/tests/chatbot-close-behavior.test.js
+++ b/tests/chatbot-close-behavior.test.js
@@ -38,9 +38,11 @@ test('Chattia closes on outside click and ESC key', async () => {
   await window.reloadChat();
   document.getElementById('chat-open-btn').click();
 
-  // outside click closes
+  // outside click minimizes
   document.body.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
-  assert.strictEqual(document.getElementById('chatbot-container'), null);
+  const minimized = document.getElementById('chatbot-container');
+  assert.ok(minimized);
+  assert.strictEqual(minimized.style.display, 'none');
 
   // reload and test ESC key
   await window.reloadChat();
@@ -48,5 +50,6 @@ test('Chattia closes on outside click and ESC key', async () => {
   assert.ok(document.getElementById('chatbot-container'));
   document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
   assert.strictEqual(document.getElementById('chatbot-container'), null);
+  assert.strictEqual(document.getElementById('chat-open-btn'), null);
 });
 


### PR DESCRIPTION
## Summary
- Ensure outside clicks minimize the chatbot instead of closing it
- Remove floating open button and session data on close to return to default FAB state
- Keep chatbot hidden until user clicks FAB; adjust tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0035d9ba4832bba8f98c496640a49