### PR TITLE
Improve chatbot minimize and session handling

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -65,6 +65,9 @@ body.kb-open #chatbot-container{
   padding:.7rem .9rem; box-shadow:0 8px 24px #0007; cursor:pointer;
   z-index:10000;
 }
+#chat-open-btn.chatbot-reopen{
+  bottom:calc(20px + 70px);
+}
 #chatbot-header{
   width:100%;
   box-sizing:border-box;

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -2,13 +2,14 @@
   const WORKER_CHAT_URL = 'https://your-cloudflare-worker.example.com/chat';
   const WORKER_END_SESSION_URL = 'https://your-cloudflare-worker.example.com/end-session';
   const WORKER_HONEYPOT_URL = 'https://your-cloudflare-worker.example.com/honeypot-trip';
+  const INACTIVITY_LIMIT_MS = window.CHATBOT_INACTIVITY_MS || 120000;
   let container, log, form, input, send, closeBtn, minimizeBtn, openBtn;
   let langCtrl, themeCtrl, brand, hpText, hpCheck;
   let hCaptchaWidgetID; // To store the ID of the invisible hCaptcha widget
   let outsideClickHandler, escKeyHandler, inactivityTimer;
   function resetInactivityTimer(){
     clearTimeout(inactivityTimer);
-    inactivityTimer = setTimeout(()=>{ closeChat(); }, 120000);
+    inactivityTimer = setTimeout(()=>{ closeChat(); }, INACTIVITY_LIMIT_MS);
   }
 
   function buildBrand(text){
@@ -29,6 +30,24 @@
     div.textContent=txt;
     log.appendChild(div);
     log.scrollTop=log.scrollHeight;
+  }
+
+  function saveHistory(){
+    if(!log) return;
+    const msgs=[...log.querySelectorAll('.chat-msg')].map(m=>({
+      cls:m.className.replace('chat-msg','').trim(),
+      txt:m.textContent
+    }));
+    try{ sessionStorage.setItem('chatHistory', JSON.stringify(msgs)); }catch(e){}
+  }
+
+  function loadHistory(){
+    try{
+      const data=sessionStorage.getItem('chatHistory');
+      if(!data) return;
+      const msgs=JSON.parse(data);
+      msgs.forEach(m=>addMsg(m.txt, m.cls));
+    }catch(e){ sessionStorage.removeItem('chatHistory'); }
   }
 
   async function reportHoneypot(reason){
@@ -128,6 +147,7 @@
     input.value='';
     autoGrow();
     updateSendEnabled();
+    sessionStorage.removeItem('chatHistory');
   }
 
   function openChat(){
@@ -135,6 +155,7 @@
     container.style.display='';
     container.removeAttribute('aria-hidden');
     openBtn.style.display='none';
+    openBtn.classList.remove('chatbot-reopen');
     openBtn.setAttribute('aria-expanded','true');
     openBtn.removeEventListener('click', openChat);
   }
@@ -143,6 +164,8 @@
     container.style.display='none';
     container.setAttribute('aria-hidden','true');
     openBtn.style.display='inline-flex';
+    openBtn.innerHTML = '<i class="fa-solid fa-comments"></i>';
+    openBtn.classList.add('chatbot-reopen');
     openBtn.setAttribute('aria-expanded','false');
     openBtn.addEventListener('click', openChat, { once:true });
     clearTimeout(inactivityTimer);
@@ -213,7 +236,7 @@
 
     escKeyHandler = (e)=>{
       if(e.key === 'Escape'){
-        closeChat();
+        minimizeChat();
       }
     };
     outsideClickHandler = (e)=>{
@@ -235,9 +258,8 @@
     // Start with chat hidden until the user explicitly opens it.
     container.style.display = 'none';
     container.setAttribute('aria-hidden', 'true');
-    openBtn.style.display = 'inline-flex';
+    openBtn.style.display = 'none';
     openBtn.setAttribute('aria-expanded', 'false');
-    openBtn.addEventListener('click', openChat, { once: true });
     loadHistory();
     renderHcaptcha();
   }
@@ -275,7 +297,6 @@
       const frag = template.content;
       document.body.appendChild(frag);
       initChatbot();
-      minimizeChat();
     }catch(err){
       console.error('Failed to reload chatbot:', err);
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -73,7 +73,7 @@
       modal.style.transition = 'none'; // Disable transition while dragging
     });
 
-    document.addEventListener('mousemove', (e) => {
+    const moveHandler = (e) => {
       if (!isDragging) return;
       e.preventDefault();
 
@@ -83,13 +83,17 @@
       modal.style.left = `${newX}px`;
       modal.style.top = `${newY}px`;
       modal.style.transform = 'none';
-    });
+    };
+    document.addEventListener('mousemove', moveHandler);
 
-    document.addEventListener('mouseup', () => {
+    const upHandler = () => {
       isDragging = false;
       modal.style.cursor = 'move';
       modal.style.transition = 'transform 0.3s ease'; // Re-enable transition
-    });
+      document.removeEventListener('mousemove', moveHandler);
+      document.removeEventListener('mouseup', upHandler);
+    };
+    document.addEventListener('mouseup', upHandler);
   }
 
   // Expose the functions to the global scope

--- a/tests/chatbot-close-behavior.test.js
+++ b/tests/chatbot-close-behavior.test.js
@@ -11,7 +11,7 @@ const html = fs.readFileSync(htmlPath, 'utf8');
 const script = fs.readFileSync(jsPath, 'utf8');
 const dragScript = fs.readFileSync(dragJsPath, 'utf8');
 const style = fs.readFileSync(cssPath, 'utf8');
-test('Chattia minimizes on outside click and closes on ESC or inactivity', async () => {
+test('Chattia minimizes on ESC or outside click and closes on inactivity', async () => {
   const dom = new JSDOM(`<body></body>`, { url: 'https://example.com', runScripts: 'dangerously' });
   const { window } = dom;
   const document = window.document;
@@ -37,15 +37,18 @@ test('Chattia minimizes on outside click and closes on ESC or inactivity', async
   window.eval(dragScript);
   window.eval(script);
 
-  // ESC closes when chat is open
+  // ESC minimizes when chat is open
   await window.reloadChat();
   window.openChatbot();
   document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-  assert.strictEqual(document.getElementById('chatbot-container'), null);
+  let minimized = document.getElementById('chatbot-container');
+  assert.ok(minimized);
+  assert.strictEqual(minimized.style.display, 'none');
 
-  // outside click minimizes
+  // outside click also minimizes
+  window.openChatbot();
   document.body.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
-  const minimized = document.getElementById('chatbot-container');
+  minimized = document.getElementById('chatbot-container');
   assert.ok(minimized);
   assert.strictEqual(minimized.style.display, 'none');
 

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -36,7 +36,7 @@ test('Chattia chatbot basic interactions', async () => {
   window.eval(dragScript);
   window.eval(script);
   await window.reloadChat();
-  document.getElementById('chat-open-btn').click();
+  window.openChatbot();
   const brand = document.getElementById('brand');
   assert.ok(brand.querySelectorAll('.char').length > 0);
   const langCtrl = document.getElementById('langCtrl');
@@ -67,7 +67,7 @@ test('Chattia chatbot basic interactions', async () => {
   document.querySelectorAll('#chatbot-container').forEach(el => el.remove());
   document.querySelectorAll('#chat-open-btn').forEach(el => el.remove());
   await window.reloadChat();
-  document.getElementById('chat-open-btn').click();
+  window.openChatbot();
   const minimizeBtn = document.getElementById('minimizeBtn');
   const container = document.getElementById('chatbot-container');
   const openBtn = document.getElementById('chat-open-btn');


### PR DESCRIPTION
## Summary
- Hide chatbot FAB by default and show chat only after FAB selection
- Minimize button now spawns a floating chat icon above the FAB menu and preserves history until 2 minutes of inactivity
- Clean up drag utility to remove listeners on mouseup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a157616ac0832bace6181402834be1