### PR TITLE
style: adjust chatbot minimize button

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -1,6 +1,9 @@
 <!-- Chatbot fragment loaded dynamically -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=chat_bubble" />
 <button id="chat-open-btn" aria-label="Open chat">
-  <i class="fa-solid fa-comments"></i>
+  <span class="material-symbols-outlined">
+    chat_bubble
+  </span>
 </button>
 <div id="chatbot-container" role="dialog" aria-modal="true" aria-label="Chattia" style="display:none" aria-hidden="true">
   <div id="chatbot-header">

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -62,11 +62,14 @@ body.kb-open #chatbot-container{
   display:none;
   background: linear-gradient(135deg,var(--clr-primary),var(--clr-accent));
   color:#fff; border:none; border-radius:999px;
-  padding:.7rem .9rem; box-shadow:0 8px 24px #0007; cursor:pointer;
+  width:56px; height:56px;
+  align-items:center; justify-content:center;
+  box-shadow:0 8px 24px #0007; cursor:pointer;
   z-index:10000;
 }
 #chat-open-btn.chatbot-reopen{
-  bottom:calc(20px + 70px);
+  bottom:calc(20px + 25px);
+  right:calc(20px + 25px);
 }
 #chatbot-header{
   width:100%;

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -162,7 +162,7 @@
     container.style.display='none';
     container.setAttribute('aria-hidden','true');
     openBtn.style.display='inline-flex';
-    openBtn.innerHTML = '<i class="fa-solid fa-comments"></i>';
+    openBtn.innerHTML = '<span class="material-symbols-outlined">chat_bubble</span>';
     openBtn.classList.add('chatbot-reopen');
     openBtn.setAttribute('aria-expanded','false');
     openBtn.addEventListener('click', openChat, { once:true });


### PR DESCRIPTION
## Summary
- replace chat reopen icon with material chat_bubble
- enlarge reopen button hitbox and offset away from FAB menu
- position minimized button with 25px top/left offset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b7d7bb68832bb6429b1fa1c032a7