### PR TITLE
feat: refine chatbot minimize and close behavior

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -61,16 +61,13 @@ body.kb-open #chatbot-container{
   position:fixed; right:20px; bottom:20px;
   display:none;
   background: linear-gradient(135deg,var(--clr-primary),var(--clr-accent));
-  color:#fff; border:none; border-radius:999px;
-  width:56px; height:56px;
+  color:#fff; border:none; border-radius:8px;
+  width:72px; height:40px;
   align-items:center; justify-content:center;
   box-shadow:0 8px 24px #0007; cursor:pointer;
   z-index:10000;
 }
-#chat-open-btn.chatbot-reopen{
-  bottom:calc(20px + 25px);
-  right:calc(20px + 25px);
-}
+#chat-open-btn.chatbot-reopen{}
 #chatbot-header{
   width:100%;
   box-sizing:border-box;

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -154,11 +154,14 @@
     container.removeAttribute('aria-hidden');
     openBtn.style.display='none';
     openBtn.classList.remove('chatbot-reopen');
+    openBtn.style.bottom='';
+    openBtn.style.right='';
     openBtn.setAttribute('aria-expanded','true');
     openBtn.removeEventListener('click', openChat);
   }
 
   function minimizeChat(){
+    saveHistory();
     container.style.display='none';
     container.setAttribute('aria-hidden','true');
     openBtn.style.display='inline-flex';
@@ -166,6 +169,18 @@
     openBtn.classList.add('chatbot-reopen');
     openBtn.setAttribute('aria-expanded','false');
     openBtn.addEventListener('click', openChat, { once:true });
+    const fabMain = document.querySelector('.fab-main');
+    const fabContainer = fabMain ? fabMain.closest('.fab-container') : null;
+    if (fabMain && fabContainer) {
+      const fabStyles = window.getComputedStyle(fabContainer);
+      const fabBottom = parseInt(fabStyles.bottom, 10) || 0;
+      const fabRight = parseInt(fabStyles.right, 10) || 0;
+      const fabHeight = parseInt(window.getComputedStyle(fabMain).height, 10) || 0;
+      const fabWidth = parseInt(window.getComputedStyle(fabMain).width, 10) || 0;
+      const btnWidth = parseInt(window.getComputedStyle(openBtn).width, 10) || 0;
+      openBtn.style.bottom = `${fabBottom + fabHeight + 10}px`;
+      openBtn.style.right = `${fabRight + (fabWidth - btnWidth) / 2}px`;
+    }
     clearTimeout(inactivityTimer);
     inactivityTimer = setTimeout(closeChat, INACTIVITY_LIMIT_MS);
   }
@@ -234,7 +249,7 @@
 
     escKeyHandler = (e)=>{
       if(e.key === 'Escape'){
-        minimizeChat();
+        closeChat();
       }
     };
     outsideClickHandler = (e)=>{

--- a/tests/chatbot-close-behavior.test.js
+++ b/tests/chatbot-close-behavior.test.js
@@ -11,7 +11,7 @@ const html = fs.readFileSync(htmlPath, 'utf8');
 const script = fs.readFileSync(jsPath, 'utf8');
 const dragScript = fs.readFileSync(dragJsPath, 'utf8');
 const style = fs.readFileSync(cssPath, 'utf8');
-test('Chattia minimizes on ESC or outside click and closes on inactivity', async () => {
+test('Chattia closes on ESC and closes on inactivity after minimize', async () => {
   const dom = new JSDOM(`<body></body>`, { url: 'https://example.com', runScripts: 'dangerously' });
   const { window } = dom;
   const document = window.document;
@@ -37,26 +37,20 @@ test('Chattia minimizes on ESC or outside click and closes on inactivity', async
   window.eval(dragScript);
   window.eval(script);
 
-  // ESC minimizes when chat is open
+  // ESC closes when chat is open
   await window.reloadChat();
   window.openChatbot();
   document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-  let minimized = document.getElementById('chatbot-container');
-  assert.ok(minimized);
-  assert.strictEqual(minimized.style.display, 'none');
+  assert.strictEqual(document.getElementById('chatbot-container'), null);
+  assert.strictEqual(document.getElementById('chat-open-btn'), null);
 
-  // outside click also minimizes
-  window.openChatbot();
-  document.body.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
-  minimized = document.getElementById('chatbot-container');
-  assert.ok(minimized);
-  assert.strictEqual(minimized.style.display, 'none');
-
-  // Inactivity after minimize closes session and removes open button
+  // outside click minimizes, then inactivity closes
   await window.reloadChat();
   window.openChatbot();
-  const minimizeBtn = document.getElementById('minimizeBtn');
-  minimizeBtn.click();
+  document.body.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+  const minimized = document.getElementById('chatbot-container');
+  assert.ok(minimized);
+  assert.strictEqual(minimized.style.display, 'none');
   await new Promise(r => setTimeout(r, 40));
   assert.strictEqual(document.getElementById('chatbot-container'), null);
   assert.strictEqual(document.getElementById('chat-open-btn'), null);

--- a/tests/chatbot-minimize-position.test.js
+++ b/tests/chatbot-minimize-position.test.js
@@ -6,7 +6,7 @@ const { JSDOM } = require('jsdom');
 
 const root = path.resolve(__dirname, '..');
 
-test('chatbot minimize positions open button above FAB by 10px', async () => {
+test('chatbot minimize positions open button above FAB by 10px and centers horizontally', async () => {
   const html = fs.readFileSync(path.join(root, 'fabs', 'chatbot.html'), 'utf8');
   const chatJs = fs.readFileSync(path.join(root, 'fabs', 'js', 'chattia.js'), 'utf8');
   const chatCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'chatbot.css'), 'utf8');
@@ -55,10 +55,16 @@ test('chatbot minimize positions open button above FAB by 10px', async () => {
   minimizeBtn.click();
 
   const fabBottom = parseInt(window.getComputedStyle(fabContainer).bottom, 10);
+  const fabRight = parseInt(window.getComputedStyle(fabContainer).right, 10);
   const fabHeight = parseInt(window.getComputedStyle(fabMain).height, 10);
-  const expected = fabBottom + fabHeight + 10;
-  const actual = parseInt(window.getComputedStyle(openBtn).bottom, 10);
-  assert.strictEqual(actual, expected);
+  const fabWidth = parseInt(window.getComputedStyle(fabMain).width, 10);
+  const btnWidth = parseInt(window.getComputedStyle(openBtn).width, 10);
+  const expectedBottom = fabBottom + fabHeight + 10;
+  const expectedRight = fabRight + (fabWidth - btnWidth) / 2;
+  const actualBottom = parseInt(window.getComputedStyle(openBtn).bottom, 10);
+  const actualRight = parseInt(window.getComputedStyle(openBtn).right, 10);
+  assert.strictEqual(actualBottom, expectedBottom);
+  assert.strictEqual(actualRight, expectedRight);
   window.cleanupChatbot();
 });
 

--- a/trap-doors.js
+++ b/trap-doors.js
@@ -474,16 +474,34 @@ document.addEventListener('DOMContentLoaded', initCojoinForms);
     container.style.display='';
     container.removeAttribute('aria-hidden');
     openBtn.style.display='none';
+    openBtn.classList.remove('chatbot-reopen');
+    openBtn.style.bottom='';
+    openBtn.style.right='';
     openBtn.setAttribute('aria-expanded','true');
     openBtn.removeEventListener('click', openChat);
   }
 
   function minimizeChat(){
+    saveHistory();
     container.style.display='none';
     container.setAttribute('aria-hidden','true');
     openBtn.style.display='inline-flex';
+    openBtn.innerHTML = '<span class="material-symbols-outlined">chat_bubble</span>';
+    openBtn.classList.add('chatbot-reopen');
     openBtn.setAttribute('aria-expanded','false');
     openBtn.addEventListener('click', openChat, { once:true });
+    const fabMain = document.querySelector('.fab-main');
+    const fabContainer = fabMain ? fabMain.closest('.fab-container') : null;
+    if (fabMain && fabContainer) {
+      const fabStyles = window.getComputedStyle(fabContainer);
+      const fabBottom = parseInt(fabStyles.bottom, 10) || 0;
+      const fabRight = parseInt(fabStyles.right, 10) || 0;
+      const fabHeight = parseInt(window.getComputedStyle(fabMain).height, 10) || 0;
+      const fabWidth = parseInt(window.getComputedStyle(fabMain).width, 10) || 0;
+      const btnWidth = parseInt(window.getComputedStyle(openBtn).width, 10) || 0;
+      openBtn.style.bottom = `${fabBottom + fabHeight + 10}px`;
+      openBtn.style.right = `${fabRight + (fabWidth - btnWidth) / 2}px`;
+    }
     clearTimeout(inactivityTimer);
     inactivityTimer = setTimeout(closeChat, INACTIVITY_LIMIT_MS);
   }


### PR DESCRIPTION
## Summary
- make chat bubble rectangular and center it above FAB when minimized
- close and clear session on ESC and after inactivity
- test chat bubble positioning and session cleanup

## Testing
- `npm test`
- `node --test tests/chatbot-minimize-position.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1d09f9408832b852f903d69a662b2