### PR TITLE
Ensure chat bubble aligns with FAB after navigation

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -85,7 +85,9 @@ body.drag-enabled #chatbot-header{ cursor:move; }
   background:transparent; border:1px solid rgba(255,255,255,.7); color:#fff;
   border-radius:8px; padding:.25rem .45rem; font-size:.8rem; cursor:pointer;
   margin-left:.5rem;
+  display:flex; align-items:center; justify-content:center;
 }
+#minimizeBtn *{ pointer-events:none; }
 #chat-log{ flex:1; overflow-y:auto; overscroll-behavior:contain; padding:1rem; background:var(--panel-3); color:#eee; font-size:.94rem }
 .chat-msg{ margin:.5rem 0; max-width:90% }
 .user{ margin-left:auto; background:var(--clr-primary); color:#000; padding:.5rem .7rem; border-radius:14px 14px 0 14px }

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -161,6 +161,22 @@
     sessionStorage.setItem('chatState','open');
   }
 
+  function positionOpenBtn(){
+    if(!openBtn) return;
+    const fabMain=document.querySelector('.fab-main');
+    const fabContainer=fabMain?fabMain.closest('.fab-container'):null;
+    if(fabMain && fabContainer){
+      const fabStyles=window.getComputedStyle(fabContainer);
+      const fabBottom=parseInt(fabStyles.bottom,10)||0;
+      const fabRight=parseInt(fabStyles.right,10)||0;
+      const fabHeight=parseInt(window.getComputedStyle(fabMain).height,10)||0;
+      const fabWidth=parseInt(window.getComputedStyle(fabMain).width,10)||0;
+      const btnWidth=parseInt(window.getComputedStyle(openBtn).width,10)||0;
+      openBtn.style.bottom=`${fabBottom + fabHeight + 10}px`;
+      openBtn.style.right=`${fabRight + (fabWidth - btnWidth) / 2}px`;
+    }
+  }
+
   function minimizeChat(){
     saveHistory();
     container.style.display='none';
@@ -171,18 +187,7 @@
     openBtn.setAttribute('aria-expanded','false');
     openBtn.addEventListener('click', openChat, { once:true });
     sessionStorage.setItem('chatState','minimized');
-    const fabMain = document.querySelector('.fab-main');
-    const fabContainer = fabMain ? fabMain.closest('.fab-container') : null;
-    if (fabMain && fabContainer) {
-      const fabStyles = window.getComputedStyle(fabContainer);
-      const fabBottom = parseInt(fabStyles.bottom, 10) || 0;
-      const fabRight = parseInt(fabStyles.right, 10) || 0;
-      const fabHeight = parseInt(window.getComputedStyle(fabMain).height, 10) || 0;
-      const fabWidth = parseInt(window.getComputedStyle(fabMain).width, 10) || 0;
-      const btnWidth = parseInt(window.getComputedStyle(openBtn).width, 10) || 0;
-      openBtn.style.bottom = `${fabBottom + fabHeight + 10}px`;
-      openBtn.style.right = `${fabRight + (fabWidth - btnWidth) / 2}px`;
-    }
+    positionOpenBtn();
     clearTimeout(inactivityTimer);
     inactivityTimer = setTimeout(closeChat, INACTIVITY_LIMIT_MS);
   }
@@ -323,6 +328,7 @@
         openBtn.classList.add('chatbot-reopen');
         openBtn.setAttribute('aria-expanded','false');
         openBtn.addEventListener('click', openChat, { once:true });
+        positionOpenBtn();
       }
     }catch(err){
       console.error('Failed to reload chatbot:', err);

--- a/tests/chatbot-minimize-position.test.js
+++ b/tests/chatbot-minimize-position.test.js
@@ -45,6 +45,7 @@ test('chatbot minimize positions open button above FAB by 10px and centers horiz
   fabContainer.appendChild(fabMain);
   document.body.appendChild(fabContainer);
 
+  window.hcaptcha = { render: () => 0 };
   window.eval(chatJs);
   await window.reloadChat();
 
@@ -53,6 +54,64 @@ test('chatbot minimize positions open button above FAB by 10px and centers horiz
 
   openBtn.click();
   minimizeBtn.click();
+
+  const fabBottom = parseInt(window.getComputedStyle(fabContainer).bottom, 10);
+  const fabRight = parseInt(window.getComputedStyle(fabContainer).right, 10);
+  const fabHeight = parseInt(window.getComputedStyle(fabMain).height, 10);
+  const fabWidth = parseInt(window.getComputedStyle(fabMain).width, 10);
+  const btnWidth = parseInt(window.getComputedStyle(openBtn).width, 10);
+  const expectedBottom = fabBottom + fabHeight + 10;
+  const expectedRight = fabRight + (fabWidth - btnWidth) / 2;
+  const actualBottom = parseInt(window.getComputedStyle(openBtn).bottom, 10);
+  const actualRight = parseInt(window.getComputedStyle(openBtn).right, 10);
+  assert.strictEqual(actualBottom, expectedBottom);
+  assert.strictEqual(actualRight, expectedRight);
+  window.cleanupChatbot();
+});
+
+test('open button repositions correctly on reload when state is minimized', async () => {
+  const html = fs.readFileSync(path.join(root, 'fabs', 'chatbot.html'), 'utf8');
+  const chatJs = fs.readFileSync(path.join(root, 'fabs', 'js', 'chattia.js'), 'utf8');
+  const chatCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'chatbot.css'), 'utf8');
+  const fabCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'cojoin.css'), 'utf8');
+
+  const dom = new JSDOM('<!DOCTYPE html><body></body>', {
+    url: 'https://example.com',
+    runScripts: 'dangerously'
+  });
+  const { window } = dom;
+  const { document } = window;
+
+  const styleEl = document.createElement('style');
+  styleEl.textContent = chatCss + fabCss;
+  document.head.appendChild(styleEl);
+
+  window.fetch = async (url) => {
+    if (url.includes('chatbot.html')) {
+      return { text: async () => html };
+    }
+    if (url.includes('honeypot') || url.includes('end-session')) {
+      return {};
+    }
+    return { json: async () => ({ reply: 'ok' }) };
+  };
+  window.alert = () => {};
+
+  const fabContainer = document.createElement('div');
+  fabContainer.className = 'fab-container';
+  const fabMain = document.createElement('button');
+  fabMain.className = 'fab-main';
+  fabMain.style.height = '60px';
+  fabMain.style.width = '60px';
+  fabContainer.appendChild(fabMain);
+  document.body.appendChild(fabContainer);
+
+  window.sessionStorage.setItem('chatState', 'minimized');
+  window.hcaptcha = { render: () => 0 };
+  window.eval(chatJs);
+  await window.reloadChat();
+
+  const openBtn = document.getElementById('chat-open-btn');
 
   const fabBottom = parseInt(window.getComputedStyle(fabContainer).bottom, 10);
   const fabRight = parseInt(window.getComputedStyle(fabContainer).right, 10);


### PR DESCRIPTION
## Summary
- Factor out helper to place the reopen button 10px above the FAB and reuse it on minimize and page reload
- Make minimize rectangle button fully clickable with flex layout and pointer-event fixes
- Cover minimized-state reload in tests to confirm positioning is preserved

## Testing
- `node --test tests/chatbot-minimize-position.test.js`
- `npm test` *(hangs, manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ec25c7c4832b8a5073081ae8dd57