### PR TITLE
Align minimize button with theme toggle

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -6,9 +6,7 @@
     <div>
       <span id="langCtrl" class="ctrl" role="button" aria-label="Toggle language">EN</span>
       &nbsp;|&nbsp;
-      <span id="themeCtrl" class="ctrl" role="button" aria-label="Toggle theme">Dark</span>
-      <button id="minimizeBtn" type="button" title="Minimize"><i class="fa-solid fa-minus"></i>
-      </button>
+      <span id="themeCtrl" class="ctrl" role="button" aria-label="Toggle theme">Dark</span><button id="minimizeBtn" type="button" title="Minimize"><i class="fa-solid fa-minus"></i></button>
     </div>
   </div>
 

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -84,8 +84,8 @@ body.drag-enabled #chatbot-header{ cursor:move; }
 #minimizeBtn{
   background:transparent; border:1px solid rgba(255,255,255,.7); color:#fff;
   border-radius:8px; padding:.25rem .45rem; font-size:.8rem; cursor:pointer;
-  margin-left:.5rem;
-  display:flex; align-items:center; justify-content:center;
+  margin-left:3px;
+  display:inline-flex; align-items:center; justify-content:center;
 }
 #minimizeBtn *{ pointer-events:none; }
 #chat-log{ flex:1; overflow-y:auto; overscroll-behavior:contain; padding:1rem; background:var(--panel-3); color:#eee; font-size:.94rem }

--- a/trap-doors.html
+++ b/trap-doors.html
@@ -285,10 +285,7 @@
     <div>
       <span id="langCtrl" class="ctrl" role="button" aria-label="Toggle language">EN</span>
       &nbsp;|&nbsp;
-      <span id="themeCtrl" class="ctrl" role="button" aria-label="Toggle theme">Dark</span>
-      <button id="minimizeBtn" type="button" title="Minimize">
-        <i class="fa-solid fa-minus"></i>
-      </button>
+      <span id="themeCtrl" class="ctrl" role="button" aria-label="Toggle theme">Dark</span><button id="minimizeBtn" type="button" title="Minimize"><i class="fa-solid fa-minus"></i></button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Place the minimize button directly beside the Dark theme toggle in the chatbot header
- Adjust spacing and display style so buttons sit inline with a 3px gap

## Testing
- ⚠️ `npm test` *(failed: process hung in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a201db9174832b95df7297886c555a