### PR TITLE
Fix language toggle labels across site

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -23,7 +23,7 @@
       <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
     </div>
     <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
+      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
       <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
         <i class="fa-solid fa-bars" aria-hidden="true"></i>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
     </div>
     <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">EN</button>
+      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
       <button type="button" class="toggle-btn theme-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-theme">Dark</button>
       <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
         <i class="fa-solid fa-bars" aria-hidden="true"></i>

--- a/it-support.html
+++ b/it-support.html
@@ -23,7 +23,7 @@
       <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
     </div>
     <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
+      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
       <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
         <i class="fa-solid fa-bars" aria-hidden="true"></i>

--- a/js/langtheme.js
+++ b/js/langtheme.js
@@ -296,7 +296,8 @@ function updateContent() {
 
   // Update language toggle buttons
   langButtons.forEach(btn => {
-    btn.textContent = currentLanguage.toUpperCase();
+    const nextLang = currentLanguage === 'en' ? 'ES' : 'EN';
+    btn.textContent = nextLang;
     btn.setAttribute('aria-pressed', currentLanguage === 'es');
   });
 }

--- a/professional-services.html
+++ b/professional-services.html
@@ -23,7 +23,7 @@
       <a href="professional-services.html" class="nav-link active" data-key="nav-professionals">Professionals</a>
     </div>
     <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
+      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
       <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
         <i class="fa-solid fa-bars" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- Show the target language on the language toggle button
- Add localized language toggle markup to all main pages

## Testing
- `npm test` *(fails: mobile menu closes on backdrop or outside click)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e823d720832b854a20d9f3e6394a