### PR TITLE
Ensure black text for Contact and Join forms

### DIFF
--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -199,25 +199,41 @@ form {
   flex-direction: column;
 }
 
-/* Ensure readable black text on the Join Us form for mobile and tablet screens */
-@media (max-width: 1024px) {
-  #joinForm,
-  #joinForm label,
-  #joinForm input,
-  #joinForm select,
-  #joinForm textarea,
-  #joinForm option,
-  #joinForm h1,
-  #joinForm h2,
-  #joinForm h3 {
-    color: #000;
-  }
+/* Ensure readable black text on the Contact Us and Join Us forms */
+#contactForm,
+#contactForm label,
+#contactForm input,
+#contactForm select,
+#contactForm textarea,
+#contactForm option,
+#contactForm h1,
+#contactForm h2,
+#contactForm h3,
+#joinForm,
+#joinForm label,
+#joinForm input,
+#joinForm select,
+#joinForm textarea,
+#joinForm option,
+#joinForm h1,
+#joinForm h2,
+#joinForm h3 {
+  color: #000;
+}
 
-  #joinForm input::placeholder,
-  #joinForm textarea::placeholder {
-    color: #000;
-    opacity: 1;
-  }
+#contactForm input::placeholder,
+#contactForm textarea::placeholder,
+#joinForm input::placeholder,
+#joinForm textarea::placeholder {
+  color: #000;
+  opacity: 1;
+}
+
+#contact-modal .modal-header,
+#join-modal .modal-header,
+#contact-modal .modal-close,
+#join-modal .modal-close {
+  color: #000;
 }
 
 label {


### PR DESCRIPTION
## Summary
- enforce black text for Contact Us and Join Us forms, including headers and placeholders
- ensure modal headers and close icons for Contact and Join modals use black text

## Testing
- `npm test` *(fails: Chattia closes on ESC; Chat history persists while minimized; chatbot minimize positions open button above FAB; open button repositions correctly on reload when minimized; Chattia chatbot basic interactions; Experience section adds numbered textareas; Continued Education section adds textarea with specific placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68a442d5cb54832bb9eb3b402e1d40ff