### PR TITLE
Fix dark/light theme toggle and add regression test

### DIFF
--- a/js/langtheme.js
+++ b/js/langtheme.js
@@ -309,7 +309,6 @@ function toggleLanguage() {
 }
 
 function updateTheme() {
-  currentTheme = window.currentTheme || currentTheme;
   document.documentElement.classList.remove('light', 'dark');
   document.documentElement.classList.add(currentTheme);
   document.documentElement.style.backgroundColor = currentTheme === 'dark' ? '#121212' : '#ffffff';

--- a/tests/theme-toggle.test.js
+++ b/tests/theme-toggle.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function createClassList() {
+  return {
+    classes: [],
+    add(...cls) { cls.forEach(c => { if (!this.classes.includes(c)) this.classes.push(c); }); },
+    remove(...cls) { this.classes = this.classes.filter(c => !cls.includes(c)); },
+    contains(c) { return this.classes.includes(c); },
+    toString() { return this.classes.join(' '); }
+  };
+}
+
+test('theme toggle updates class, text, and localStorage', () => {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'js', 'langtheme.js'), 'utf-8');
+
+  const themeButton = {
+    textContent: 'Dark',
+    attributes: {},
+    setAttribute(k, v) { this.attributes[k] = v; },
+    getAttribute(k) { return this.attributes[k]; },
+    addEventListener(event, cb) { this.onClick = cb; }
+  };
+
+  const document = {
+    documentElement: { classList: createClassList(), style: {} },
+    querySelectorAll(sel) {
+      if (sel === '.theme-toggle') return [themeButton];
+      if (sel === '.lang-toggle') return [];
+      if (sel === '[data-key]') return [];
+      if (sel === '[data-aria-label-key]') return [];
+      return [];
+    },
+    addEventListener(event, cb) { if (event === 'DOMContentLoaded') cb(); }
+  };
+
+  const localStorage = {
+    store: {},
+    getItem(k) { return this.store[k]; },
+    setItem(k, v) { this.store[k] = v; }
+  };
+
+  const sandbox = { document, localStorage, console };
+  sandbox.window = sandbox;
+  vm.runInNewContext(code, sandbox);
+
+  assert.ok(document.documentElement.classList.contains('light'));
+  assert.strictEqual(themeButton.textContent, 'Dark');
+
+  themeButton.onClick();
+  assert.ok(document.documentElement.classList.contains('dark'));
+  assert.strictEqual(localStorage.getItem('theme'), 'dark');
+  assert.strictEqual(themeButton.textContent, 'Light');
+  assert.strictEqual(themeButton.attributes['aria-pressed'], true);
+
+  themeButton.onClick();
+  assert.ok(document.documentElement.classList.contains('light'));
+  assert.strictEqual(localStorage.getItem('theme'), 'light');
+  assert.strictEqual(themeButton.textContent, 'Dark');
+  assert.strictEqual(themeButton.attributes['aria-pressed'], false);
+});


### PR DESCRIPTION
## Summary
- fix theme switcher by using current theme state directly
- add unit test ensuring theme toggle updates DOM and localStorage

## Testing
- `npm test` *(fails: Chattia closes on ESC and closes on inactivity after minimize, Chat history persists while minimized and clears on close, chatbot minimize positions open button above FAB by 10px and centers horizontally, open button repositions correctly on reload when state is minimized, Chattia chatbot basic interactions, Experience section adds numbered textareas, Continued Education section adds textarea with specific placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68a44306ca40832bba7ac68459840a8c