### PR TITLE
chore: refine robots.txt for bot access

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,68 @@
-User-agent: *
-Allow: /
-Sitemap: /sitemap.xml
+# Block AI crawlers
+User-agent: GPTBot
+Disallow: /
 
+User-agent: Anthropic-ai
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+# Allow search engines
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: Slurp
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: YandexBot
+Allow: /
+
+User-agent: Baiduspider
+Allow: /
+
+# Allow other service bots
+User-agent: Applebot
+Allow: /
+
+User-agent: PetalBot
+Allow: /
+
+# Allow social media link previews
+User-agent: facebookexternalhit
+Allow: /
+
+User-agent: Twitterbot
+Allow: /
+
+User-agent: LinkedInBot
+Allow: /
+
+User-agent: Slackbot
+Allow: /
+
+User-agent: Discordbot
+Allow: /
+
+User-agent: WhatsApp
+Allow: /
+
+User-agent: Pinterestbot
+Allow: /
+
+Sitemap: /sitemap.xml


### PR DESCRIPTION
## Summary
- block major AI crawlers from indexing
- allow mainstream search engines, Applebot, PetalBot, and social media preview bots

## Testing
- `npm test` (fails: Subtests failing 7/50)

------
https://chatgpt.com/codex/tasks/task_e_68a58ba2a3e4832b9de75a5d67600eb1