### PR TITLE
Fix theme toggle synchronization for Chattia

### DIFF
--- a/js/langtheme.js
+++ b/js/langtheme.js
@@ -309,6 +309,7 @@ function toggleLanguage() {
 }
 
 function updateTheme() {
+  currentTheme = window.currentTheme || currentTheme || 'light';
   document.documentElement.classList.remove('light', 'dark');
   document.documentElement.classList.add(currentTheme);
   document.documentElement.style.backgroundColor = currentTheme === 'dark' ? '#121212' : '#ffffff';
@@ -322,6 +323,7 @@ function updateTheme() {
 
 function toggleTheme() {
   currentTheme = (currentTheme === 'light') ? 'dark' : 'light';
+  window.currentTheme = currentTheme;
   localStorage.setItem('theme', currentTheme);
   updateTheme();
 }


### PR DESCRIPTION
## Summary
- Sync global theme state with Chattia's toggle so dark mode applies correctly

## Testing
- `node --test tests/theme-toggle.test.js`
- `npm test` *(fails: process exited before completing)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d8d0120832bb270762b976eae94