### PR TITLE
Fix chatbot control actions with delegated events

### DIFF
--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -224,34 +224,52 @@
     }
     if (langCtrl) {
       langCtrl.textContent = 'ES';
-      langCtrl.addEventListener('click', () => {
-        const goES = langCtrl.textContent === 'ES';
+    }
+    // Delegated click handling for header controls and buttons
+    container.addEventListener('click', (e) => {
+      const langEl = e.target.closest('#langCtrl');
+      const themeEl = e.target.closest('#themeCtrl');
+      const minimizeEl = e.target.closest('#minimizeBtn');
+      const closeEl = e.target.closest('#chatbot-close');
+
+      if (langEl) {
+        const goES = langEl.textContent === 'ES';
         document.documentElement.lang = goES ? 'es' : 'en';
-        langCtrl.textContent = goES ? 'EN' : 'ES';
+        langEl.textContent = goES ? 'EN' : 'ES';
         transNodes.forEach(n => n.textContent = goES ? (n.dataset.es || n.textContent) : (n.dataset.en || n.textContent));
         phNodes.forEach(n => n.placeholder = goES ? (n.dataset.esPh || n.placeholder) : (n.dataset.enPh || n.placeholder));
         buildBrand(goES ? (brand.dataset.es || 'Soporte en Línea OPS') : (brand.dataset.en || 'Ops Online Support'));
-      });
-    }
-    if (themeCtrl) {
-      themeCtrl.addEventListener('click', () => {
-        const toDark = themeCtrl.textContent === 'Dark';
+      } else if (themeEl) {
+        const toDark = themeEl.textContent === 'Dark';
         window.currentTheme = toDark ? 'dark' : 'light';
         localStorage.setItem('theme', window.currentTheme);
         if (typeof updateTheme === 'function') { updateTheme(); }
-        themeCtrl.textContent = toDark ? 'Light' : 'Dark';
-      });
-    }
+        themeEl.textContent = toDark ? 'Light' : 'Dark';
+      } else if (minimizeEl) {
+        minimizeChat();
+      } else if (closeEl) {
+        closeChat();
+      }
+    });
 
     if (input) {
       input.addEventListener('input', () => { autoGrow(); updateSendEnabled(); });
-      input.addEventListener('keydown', e => { if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); if(!send.disabled && form) form.requestSubmit(); }});
+      input.addEventListener('keydown', e => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          if (!send.disabled && form) {
+            if (typeof form.requestSubmit === 'function') {
+              form.requestSubmit();
+            } else {
+              form.dispatchEvent(new Event('submit', { cancelable: true }));
+            }
+          }
+        }
+      });
     }
     window.addEventListener('load', () => { autoGrow(); updateSendEnabled(); });
 
     if (form) { form.addEventListener('submit', handleSubmit); }
-    if (minimizeBtn) { minimizeBtn.addEventListener('click', minimizeChat); }
-    if (closeBtn) { closeBtn.addEventListener('click', closeChat); }
 
     escKeyHandler = (e)=>{
       if(e.key === 'Escape'){

--- a/tests/chatbot-controls.test.js
+++ b/tests/chatbot-controls.test.js
@@ -1,0 +1,75 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { JSDOM } = require('jsdom');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const htmlPath = path.join(__dirname, '..', 'fabs', 'chatbot.html');
+const jsPath = path.join(__dirname, '..', 'fabs', 'js', 'chattia.js');
+const dragJsPath = path.join(__dirname, '..', 'fabs', 'js', 'cojoin.js');
+const cssPath = path.join(__dirname, '..', 'fabs', 'css', 'chatbot.css');
+const antibotJs = fs.readFileSync(path.join(__dirname, '..', 'js', 'antibot.js'), 'utf8');
+const utilsJs = fs.readFileSync(path.join(__dirname, '..', 'js', 'utils.js'), 'utf8');
+const langThemeJs = fs.readFileSync(path.join(__dirname, '..', 'js', 'langtheme.js'), 'utf8');
+const html = fs.readFileSync(htmlPath, 'utf8');
+const script = fs.readFileSync(jsPath, 'utf8');
+const dragScript = fs.readFileSync(dragJsPath, 'utf8');
+const style = fs.readFileSync(cssPath, 'utf8');
+const hpHtml = fs.readFileSync(path.join(__dirname, '..', 'security', 'honeypots.html'), 'utf8');
+
+test('Chatbot header controls and send button work', async () => {
+  const dom = new JSDOM(`<body></body>`, { url: 'https://opsonlinessupport.com', runScripts: 'dangerously' });
+  const { window } = dom;
+  const document = window.document;
+  window.innerWidth = 1024;
+  const styleEl = document.createElement('style');
+  styleEl.textContent = style;
+  document.head.appendChild(styleEl);
+  window.fetch = async (url) => {
+    if (url && url.includes('chatbot.html')) {
+      return { text: async () => html };
+    }
+    if (url && url.includes('security/honeypots.html')) {
+      return { ok: true, text: async () => hpHtml };
+    }
+    if (url && url.includes('honeypot')) {
+      return {};
+    }
+    if (url && url.includes('end-session')) {
+      return {};
+    }
+    return { json: async () => ({ reply: 'ok' }) };
+  };
+  window.alert = () => {};
+  window.grecaptcha = { ready: cb => cb(), execute: async () => 'token' };
+  window.eval(utilsJs);
+  window.eval(antibotJs);
+  window.eval(langThemeJs);
+  window.eval(dragScript);
+  window.eval(script);
+
+  await window.reloadChat();
+  window.openChatbot();
+
+  const langCtrl = document.getElementById('langCtrl');
+  langCtrl.click();
+  assert.strictEqual(langCtrl.textContent, 'EN');
+
+  const themeCtrl = document.getElementById('themeCtrl');
+  const initialTheme = themeCtrl.textContent;
+  themeCtrl.click();
+  assert.notStrictEqual(themeCtrl.textContent, initialTheme);
+
+  const input = document.getElementById('chatbot-input');
+  input.value = 'hi';
+  input.dispatchEvent(new window.Event('input'));
+  document.getElementById('chatbot-send').click();
+  const messages = [...document.querySelectorAll('#chat-log .chat-msg.user')];
+  assert.ok(messages.some(m => m.textContent === 'hi'));
+
+  document.getElementById('minimizeBtn').click();
+  assert.strictEqual(document.getElementById('chatbot-container').style.display, 'none');
+  window.openChatbot();
+  document.getElementById('chatbot-close').click();
+  assert.strictEqual(document.getElementById('chatbot-container'), null);
+});


### PR DESCRIPTION
## Summary
- handle chatbot header controls and buttons via delegated click events
- add enter key fallback for wider browser support
- test chatbot language/theme toggles, send, minimize, and close actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a68d639ce8832ba0a6766843e37af2