### PR TITLE
Move search controls to footer

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -33,11 +33,6 @@
 <body class="page-contact-center">
   <nav class="ops-nav">
     <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
-    <div class="search-container">
-      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
-      <button id="search-button" aria-label="Search"><i class="fa fa-search"></i></button>
-      <button id="voice-search-button" aria-label="Voice Search"><i class="fa fa-microphone"></i></button>
-    </div>
     <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link active" data-key="nav-contact-center">Contact Center</a>
@@ -87,7 +82,13 @@
     </section>
     <div id="search-results"></div>
   </main>
-  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.</footer>
+  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.
+    <div class="search-container">
+      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
+      <button id="search-button" aria-label="Search"><i class="fa fa-search"></i></button>
+      <button id="voice-search-button" aria-label="Voice Search"><i class="fa fa-microphone"></i></button>
+    </div>
+  </footer>
   <div id="modal-root"></div>
     <script src="js/langtheme.js" defer></script>
     <script src="js/main.js" defer></script>

--- a/css/style.css
+++ b/css/style.css
@@ -258,9 +258,12 @@ li {
 
 /* Search Container */
 .search-container {
+  position: fixed;
+  right: 20px;
+  bottom: 65px;
   display: flex;
   align-items: center;
-  margin-right: 1rem;
+  z-index: 1000;
 }
 
 #search-input {

--- a/index.html
+++ b/index.html
@@ -34,11 +34,6 @@
 <body class="page-business-ops">
   <nav class="ops-nav">
     <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
-    <div class="search-container">
-      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
-      <button id="search-button" aria-label="Search"><i class="fa fa-search"></i></button>
-      <button id="voice-search-button" aria-label="Voice Search"><i class="fa fa-microphone"></i></button>
-    </div>
     <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link active" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
@@ -92,7 +87,13 @@
     </section>
     <div id="search-results"></div>
   </main>
-  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.</footer>
+  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.
+    <div class="search-container">
+      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
+      <button id="search-button" aria-label="Search"><i class="fa fa-search"></i></button>
+      <button id="voice-search-button" aria-label="Voice Search"><i class="fa fa-microphone"></i></button>
+    </div>
+  </footer>
   <div id="modal-root"></div>
   <script src="js/utils.js" defer></script>
     <script src="js/langtheme.js" defer></script>

--- a/it-support.html
+++ b/it-support.html
@@ -33,11 +33,6 @@
 <body class="page-it-support">
   <nav class="ops-nav">
     <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
-    <div class="search-container">
-      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
-      <button id="search-button" aria-label="Search"><i class="fa fa-search"></i></button>
-      <button id="voice-search-button" aria-label="Voice Search"><i class="fa fa-microphone"></i></button>
-    </div>
     <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
@@ -86,7 +81,13 @@
     </section>
     <div id="search-results"></div>
   </main>
-  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.</footer>
+  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.
+    <div class="search-container">
+      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
+      <button id="search-button" aria-label="Search"><i class="fa fa-search"></i></button>
+      <button id="voice-search-button" aria-label="Voice Search"><i class="fa fa-microphone"></i></button>
+    </div>
+  </footer>
   <div id="modal-root"></div>
     <script src="js/langtheme.js" defer></script>
     <script src="js/main.js" defer></script>

--- a/js/search.js
+++ b/js/search.js
@@ -20,6 +20,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const results = searchIndex.filter(page => page.content.toLowerCase().includes(query));
 
+    if (results.length === 1) {
+      window.location.href = results[0].url;
+      return;
+    }
+
     displayResults(results);
   };
 

--- a/professional-services.html
+++ b/professional-services.html
@@ -33,11 +33,6 @@
 <body class="page-professional-services">
   <nav class="ops-nav">
     <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
-    <div class="search-container">
-      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
-      <button id="search-button" aria-label="Search"><i class="fa fa-search"></i></button>
-      <button id="voice-search-button" aria-label="Voice Search"><i class="fa fa-microphone"></i></button>
-    </div>
     <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
@@ -92,7 +87,13 @@
     </section>
     <div id="search-results"></div>
   </main>
-  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.</footer>
+  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.
+    <div class="search-container">
+      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
+      <button id="search-button" aria-label="Search"><i class="fa fa-search"></i></button>
+      <button id="voice-search-button" aria-label="Voice Search"><i class="fa fa-microphone"></i></button>
+    </div>
+  </footer>
   <div id="modal-root"></div>
     <script src="js/langtheme.js" defer></script>
     <script src="js/main.js" defer></script>


### PR DESCRIPTION
## Summary
- relocate search and voice buttons from navigation bar to footer
- fix search container to bottom-right of viewport with 65px offset
- redirect searches directly to the first matching page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aada96c048832b9636d6754b566c09