### PR TITLE
Make service cards navigable and update FAB chatbot label

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const contactFab = createFabOption('contact', '<i class="fa fa-envelope"></i>', 'Contact Us');
   const joinFab = createFabOption('join', '<i class="fa fa-user-plus"></i>', 'Join Us');
-  const chatbotFab = createFabOption('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot');
+  const chatbotFab = createFabOption('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot Chattia');
 
   fabOptions.appendChild(contactFab);
   fabOptions.appendChild(joinFab);

--- a/js/main.js
+++ b/js/main.js
@@ -206,6 +206,21 @@ document.addEventListener('DOMContentLoaded', () => {
       const service = translations.services[serviceKey];
       if (service && service.learn) {
         el.setAttribute('href', service.learn);
+        // Make entire card act as a link to the service page
+        card.setAttribute('role', 'link');
+        card.tabIndex = 0;
+        const navigate = () => { window.location.href = service.learn; };
+        card.addEventListener('click', e => {
+          if (!e.target.closest('.learn-more')) {
+            navigate();
+          }
+        });
+        card.addEventListener('keydown', e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            navigate();
+          }
+        });
       }
       return;
     }


### PR DESCRIPTION
## Summary
- Make entire service cards accessible links that navigate to their pages
- Label chatbot FAB option as "Chatbot Chattia" for clarity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b02d173c90832b9d93a2ced2659739