### PR TITLE
chore: update worker asset URLs

### DIFF
--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -156,10 +156,10 @@ function initCojoinForms() {
     }
     sanitizedData.nonce = crypto.randomUUID();
     alert('Contact form submitted successfully!');
-    await sendToCloudflareWorker(
-      sanitizedData,
-      'https://contact-intake.pure-sail-sole.workers.dev'
-    );
+      await sendToCloudflareWorker(
+        sanitizedData,
+        'https://ops-contact-intake.pure-sail-sole.workers.dev'
+      );
     form.reset();
     if (window.hideActiveFabModal) {
       window.hideActiveFabModal();
@@ -197,10 +197,10 @@ function initCojoinForms() {
     }
     sanitizedData.nonce = crypto.randomUUID();
     alert('Join form submitted successfully!');
-    await sendToCloudflareWorker(
-      sanitizedData,
-      'https://join-intake.pure-sail-sole.workers.dev'
-    );
+      await sendToCloudflareWorker(
+        sanitizedData,
+        'https://ops-join-intake.pure-sail-sole.workers.dev'
+      );
     form.reset();
     resetJoinFormState();
     if (window.hideActiveFabModal) {

--- a/ops-workers/contact-intake/wrangler.toml
+++ b/ops-workers/contact-intake/wrangler.toml
@@ -4,6 +4,7 @@ compatibility_date = "2024-01-30"
 [vars]
 ALLOWED_ORIGINS = "https://www.opsonlinesupport.com"
 ASSET_ID = "ops-contact-intake"
+ASSET_URL = "https://ops-contact-intake.pure-sail-sole.workers.dev"
 TRANSIT_URL = "https://ops-transit-broker.pure-sail-sole.workers.dev"
 MAX_BODY_BYTES = "256000"
 MAX_FIELD_BYTES = "5000"

--- a/ops-workers/join-intake/wrangler.toml
+++ b/ops-workers/join-intake/wrangler.toml
@@ -4,6 +4,7 @@ compatibility_date = "2024-01-30"
 [vars]
 ALLOWED_ORIGINS = "https://www.opsonlinesupport.com"
 ASSET_ID = "ops-join-intake"
+ASSET_URL = "https://ops-join-intake.pure-sail-sole.workers.dev"
 TRANSIT_URL = "https://ops-transit-broker.pure-sail-sole.workers.dev"
 MAX_BODY_BYTES = "256000"
 MAX_FIELD_BYTES = "5000"

--- a/ops-workers/transit-broker/wrangler.toml
+++ b/ops-workers/transit-broker/wrangler.toml
@@ -1,3 +1,4 @@
 [vars]
 ASSET_ID = "ops-transit-broker"
+ASSET_URL = "https://ops-transit-broker.pure-sail-sole.workers.dev"
 ALLOWED_ORIGINS = "https://www.opsonlinesupport.com"


### PR DESCRIPTION
## Summary
- add explicit ASSET_URL entries for contact, join, and transit workers
- route FAB forms to updated ops- worker endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b03d4195d8832ba1c1d3403d58a33c