### PR TITLE
feat: use distinct asset ids for fab forms

### DIFF
--- a/fabs/js/fab-handlers.js
+++ b/fabs/js/fab-handlers.js
@@ -36,6 +36,9 @@ async function handleSubmit(event, workerUrl) {
   }
 
   const formType = form.id === 'contactForm' ? 'contact' : 'join';
+  const assetID = formType === 'contact'
+    ? 'FABs_assetID_llamanos'
+    : 'FABs_assetID_unete';
 
   const validatedData = { skills: [], education: [], certification: [], hobbies: [], continuedEducation: [], experience: [] };
 
@@ -112,7 +115,7 @@ async function handleSubmit(event, workerUrl) {
         signature: Array.from(new Uint8Array(signature)),
         publicKey: Array.from(new Uint8Array(exportedPublicKey)),
         aesKey: Array.from(new Uint8Array(exportedKey)),
-        assetID: 'FABs_assetID_1234'
+        assetID
       })
     });
 


### PR DESCRIPTION
## Summary
- send contact form payloads with `FABs_assetID_llamanos`
- send join form payloads with `FABs_assetID_unete`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4581ee5cc832bbf837cdc76f06fa7