### PR TITLE
Align footer search controls and reposition copyright

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -280,6 +280,9 @@ li {
   padding: 0.5rem;
   border-radius: 0;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #voice-search-button {
@@ -289,6 +292,9 @@ li {
   padding: 0.5rem;
   border-radius: 0 4px 4px 0;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #search-results {
@@ -331,19 +337,20 @@ li {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  justify-content: center;
 }
 
 .footer-info {
-  flex: 1;
-  text-align: center;
+  position: absolute;
+  left: 25px;
+  text-align: left;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.5rem;
 }
 
 .ops-footer .search-container {
-  margin-left: auto;
-  margin-right: 50px;
+  margin: 0 auto;
 }
 
 .ops-footer .sitemap-link {
@@ -362,6 +369,13 @@ li {
     flex-direction: column-reverse;
     align-items: center;
     gap: var(--space-sm);
+  }
+
+  .footer-info {
+    position: static;
+    margin-left: 0;
+    text-align: center;
+    justify-content: center;
   }
 
   .ops-footer .search-container {


### PR DESCRIPTION
## Summary
- Center search and voice buttons within footer for consistent alignment
- Fix footer layout: center search bar and move copyright text to left margin
- Adjust mobile footer to keep elements positioned correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6199bdb98832bb94812546523639a