### PR TITLE
feat: move search bar to header

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -32,20 +32,29 @@
 </head>
 <body class="page-contact-center">
   <nav class="ops-nav">
-    <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
-    <div class="nav-links" id="primary-nav">
-      <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
-      <a href="contact-center.html" class="nav-link active" data-key="nav-contact-center">Contact Center</a>
-      <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
-      <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
+    <div class="nav-top">
+      <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
+      <div class="search-container">
+        <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
+        <button id="search-button" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></button>
+        <button id="voice-search-button" aria-label="Voice Search"><i class="fa-solid fa-microphone" aria-hidden="true"></i></button>
+      </div>
     </div>
-    <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
-      <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
-      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
-        <i class="fa-solid fa-bars" aria-hidden="true"></i>
-        <span class="sr-only" data-key="nav-menu">Menu</span>
-      </button>
+    <div class="nav-bottom">
+      <div class="nav-links" id="primary-nav">
+        <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
+        <a href="contact-center.html" class="nav-link active" data-key="nav-contact-center">Contact Center</a>
+        <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
+        <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
+      </div>
+      <div class="toggles">
+        <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
+        <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+        <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+          <span class="sr-only" data-key="nav-menu">Menu</span>
+        </button>
+      </div>
     </div>
   </nav>
 
@@ -86,11 +95,6 @@
     <div class="footer-info">
       <span>© 2025 OPS Online Support.</span>
       <a href="sitemap.xml" class="sitemap-link">Site Map</a>
-    </div>
-    <div class="search-container">
-      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
-      <button id="search-button" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></button>
-      <button id="voice-search-button" aria-label="Voice Search"><i class="fa-solid fa-microphone" aria-hidden="true"></i></button>
     </div>
   </footer>
   <div id="modal-root"></div>

--- a/css/style.css
+++ b/css/style.css
@@ -38,7 +38,7 @@
   --space-3xl: 60px;
 
   /* Layout */
-  --nav-header-height: 85px; /* height of sticky nav header */
+  --nav-header-height: 120px; /* height of sticky nav header */
 }
 
 /* Dark Theme Variables */
@@ -169,23 +169,39 @@ li {
   max-width: 1240px;
   margin: 0 auto;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
+  align-items: stretch;
   padding: 1.2rem 2rem;
   font-weight: 600;
+}
+
+.nav-top,
+.nav-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.nav-top {
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.nav-bottom {
+  margin-top: var(--space-sm);
 }
 
 .ops-logo {
   font-family: "Segoe UI", Arial, sans-serif;
   font-weight: bold;
-  font-size: 2rem;
+  font-size: 3rem;
   color: var(--clr-text);
   text-decoration: none;
   letter-spacing: 2px;
   text-shadow: 0 0 8px var(--clr-logo-shadow);
   user-select: none;
-  position: absolute;
-  left: var(--space-sm);
+  flex-shrink: 0;
 }
 
 .nav-links {
@@ -214,9 +230,7 @@ li {
 .toggles {
   display: flex;
   gap: 0.5rem;
-  position: absolute;
-  top: 1.2rem;
-  right: var(--space-sm);
+  margin-left: auto;
 }
 
 .toggle-btn,
@@ -261,6 +275,10 @@ li {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
+}
+
+.nav-top .search-container {
+  flex: 1 1 300px;
 }
 
 #search-input {
@@ -336,7 +354,6 @@ li {
   border-top: 1px solid var(--clr-form-border);
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
   justify-content: center;
 }
 
@@ -347,10 +364,6 @@ li {
   display: flex;
   justify-content: flex-start;
   gap: 0.5rem;
-}
-
-.ops-footer .search-container {
-  margin: 0 auto;
 }
 
 .ops-footer .sitemap-link {
@@ -366,7 +379,7 @@ li {
 
 @media (max-width: 600px) {
   .ops-footer {
-    flex-direction: column-reverse;
+    flex-direction: column;
     align-items: center;
     gap: var(--space-sm);
   }
@@ -376,15 +389,6 @@ li {
     margin-left: 0;
     text-align: center;
     justify-content: center;
-  }
-
-  .ops-footer .search-container {
-    margin: 0 auto;
-  }
-
-  #search-input {
-    width: 70vw;
-    max-width: 300px;
   }
 }
 
@@ -744,18 +748,22 @@ li {
     padding-bottom: calc(var(--space-lg) * 4 + var(--space-sm)); /* extra space for fixed toggles */
   }
   .ops-nav {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
     overflow-x: auto;
   }
 
-  .ops-nav .ops-logo {
-    font-size: 3rem;
-    position: static;
-    left: auto;
-    flex-shrink: 0;
-    margin-left: var(--space-sm);
+  .nav-top {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-top .search-container {
+    width: 100%;
+    margin-top: var(--space-sm);
+  }
+
+  #search-input {
+    width: 100%;
+    max-width: none;
   }
 
   h1 {

--- a/index.html
+++ b/index.html
@@ -33,20 +33,29 @@
 </head>
 <body class="page-business-ops">
   <nav class="ops-nav">
-    <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
-    <div class="nav-links" id="primary-nav">
-      <a href="index.html" class="nav-link active" data-key="nav-business-ops">Business Operations</a>
-      <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
-      <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
-      <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
+    <div class="nav-top">
+      <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
+      <div class="search-container">
+        <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
+        <button id="search-button" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></button>
+        <button id="voice-search-button" aria-label="Voice Search"><i class="fa-solid fa-microphone" aria-hidden="true"></i></button>
+      </div>
     </div>
-    <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
-      <button type="button" class="toggle-btn theme-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-theme">Dark</button>
-      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
-        <i class="fa-solid fa-bars" aria-hidden="true"></i>
-        <span class="sr-only" data-key="nav-menu">Menu</span>
-      </button>
+    <div class="nav-bottom">
+      <div class="nav-links" id="primary-nav">
+        <a href="index.html" class="nav-link active" data-key="nav-business-ops">Business Operations</a>
+        <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
+        <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
+        <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
+      </div>
+      <div class="toggles">
+        <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
+        <button type="button" class="toggle-btn theme-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-theme">Dark</button>
+        <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+          <span class="sr-only" data-key="nav-menu">Menu</span>
+        </button>
+      </div>
     </div>
   </nav>
   <div class="nav-backdrop" hidden></div>
@@ -87,15 +96,10 @@
     </section>
     <div id="search-results"></div>
   </main>
-    <footer class="ops-footer" role="contentinfo">
+  <footer class="ops-footer" role="contentinfo">
     <div class="footer-info">
       <span>© 2025 OPS Online Support.</span>
       <a href="sitemap.xml" class="sitemap-link">Site Map</a>
-    </div>
-    <div class="search-container">
-      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
-      <button id="search-button" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></button>
-      <button id="voice-search-button" aria-label="Voice Search"><i class="fa-solid fa-microphone" aria-hidden="true"></i></button>
     </div>
   </footer>
   <div id="modal-root"></div>

--- a/it-support.html
+++ b/it-support.html
@@ -32,20 +32,29 @@
 </head>
 <body class="page-it-support">
   <nav class="ops-nav">
-    <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
-    <div class="nav-links" id="primary-nav">
-      <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
-      <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
-      <a href="it-support.html" class="nav-link active" data-key="nav-it-support">IT Support</a>
-      <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
+    <div class="nav-top">
+      <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
+      <div class="search-container">
+        <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
+        <button id="search-button" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></button>
+        <button id="voice-search-button" aria-label="Voice Search"><i class="fa-solid fa-microphone" aria-hidden="true"></i></button>
+      </div>
     </div>
-    <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
-      <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
-      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
-        <i class="fa-solid fa-bars" aria-hidden="true"></i>
-        <span class="sr-only" data-key="nav-menu">Menu</span>
-      </button>
+    <div class="nav-bottom">
+      <div class="nav-links" id="primary-nav">
+        <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
+        <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
+        <a href="it-support.html" class="nav-link active" data-key="nav-it-support">IT Support</a>
+        <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
+      </div>
+      <div class="toggles">
+        <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
+        <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+        <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+          <span class="sr-only" data-key="nav-menu">Menu</span>
+        </button>
+      </div>
     </div>
   </nav>
 
@@ -85,11 +94,6 @@
     <div class="footer-info">
       <span>© 2025 OPS Online Support.</span>
       <a href="sitemap.xml" class="sitemap-link">Site Map</a>
-    </div>
-    <div class="search-container">
-      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
-      <button id="search-button" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></button>
-      <button id="voice-search-button" aria-label="Voice Search"><i class="fa-solid fa-microphone" aria-hidden="true"></i></button>
     </div>
   </footer>
   <div id="modal-root"></div>

--- a/professional-services.html
+++ b/professional-services.html
@@ -32,20 +32,29 @@
 </head>
 <body class="page-professional-services">
   <nav class="ops-nav">
-    <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
-    <div class="nav-links" id="primary-nav">
-      <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
-      <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
-      <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
-      <a href="professional-services.html" class="nav-link active" data-key="nav-professionals">Professionals</a>
+    <div class="nav-top">
+      <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
+      <div class="search-container">
+        <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
+        <button id="search-button" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></button>
+        <button id="voice-search-button" aria-label="Voice Search"><i class="fa-solid fa-microphone" aria-hidden="true"></i></button>
+      </div>
     </div>
-    <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
-      <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
-      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
-        <i class="fa-solid fa-bars" aria-hidden="true"></i>
-        <span class="sr-only" data-key="nav-menu">Menu</span>
-      </button>
+    <div class="nav-bottom">
+      <div class="nav-links" id="primary-nav">
+        <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
+        <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
+        <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
+        <a href="professional-services.html" class="nav-link active" data-key="nav-professionals">Professionals</a>
+      </div>
+      <div class="toggles">
+        <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">ES</button>
+        <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+        <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="" data-aria-label-key="aria-nav-menu">
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+          <span class="sr-only" data-key="nav-menu">Menu</span>
+        </button>
+      </div>
     </div>
   </nav>
 
@@ -91,11 +100,6 @@
     <div class="footer-info">
       <span>© 2025 OPS Online Support.</span>
       <a href="sitemap.xml" class="sitemap-link">Site Map</a>
-    </div>
-    <div class="search-container">
-      <input type="search" id="search-input" placeholder="Search..." aria-label="Search">
-      <button id="search-button" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></button>
-      <button id="voice-search-button" aria-label="Voice Search"><i class="fa-solid fa-microphone" aria-hidden="true"></i></button>
     </div>
   </footer>
   <div id="modal-root"></div>


### PR DESCRIPTION
## Summary
- relocate site search with voice input into header under OPS logo
- enlarge OPS logo and reorganize nav layout for better responsiveness
- remove footer search bar and adjust styles accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b65d4b8f8c832b9a9786daeff4ecf0