### PR TITLE
Ensure DOMPurify loads before antibot script

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -101,6 +101,7 @@
     <script src="js/langtheme.js" defer></script>
     <script src="js/main.js" defer></script>
     <script src="js/search.js" defer></script>
+    <script src="https://unpkg.com/dompurify@3.0.6/dist/purify.min.js"></script>
     <script src="js/antibot.js"></script>
     <script src="fabs/js/cojoin.js"></script>
     <script type="module" src="fabs/js/fab-handlers.js"></script>

--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
     <script src="js/langtheme.js" defer></script>
     <script src="js/main.js" defer></script>
     <script src="js/search.js" defer></script>
+    <script src="https://unpkg.com/dompurify@3.0.6/dist/purify.min.js"></script>
     <script src="js/antibot.js"></script>
     <script src="fabs/js/cojoin.js"></script>
     <script type="module" src="fabs/js/fab-handlers.js"></script>

--- a/it-support.html
+++ b/it-support.html
@@ -100,6 +100,7 @@
     <script src="js/langtheme.js" defer></script>
     <script src="js/main.js" defer></script>
     <script src="js/search.js" defer></script>
+    <script src="https://unpkg.com/dompurify@3.0.6/dist/purify.min.js"></script>
     <script src="js/antibot.js"></script>
     <script src="fabs/js/cojoin.js"></script>
     <script type="module" src="fabs/js/fab-handlers.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "improved-fortnight",
+  "name": "improved-forknight",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "improved-fortnight",
+      "name": "improved-forknight",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "improved-fortnight",
+  "name": "improved-forknight",
   "version": "1.0.0",
   "description": "",
   "main": "gestion-test",

--- a/professional-services.html
+++ b/professional-services.html
@@ -106,6 +106,7 @@
     <script src="js/langtheme.js" defer></script>
     <script src="js/main.js" defer></script>
     <script src="js/search.js" defer></script>
+    <script src="https://unpkg.com/dompurify@3.0.6/dist/purify.min.js"></script>
     <script src="js/antibot.js"></script>
     <script src="fabs/js/cojoin.js"></script>
     <script type="module" src="fabs/js/fab-handlers.js"></script>


### PR DESCRIPTION
## Summary
- load DOMPurify from CDN before antibot script on all pages that use the honeypot utility
- set package name to improved-forknight in package metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b748af47b4832ba0090612efedf9d1