### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -37,12 +37,25 @@
         return div.textContent;
       } catch (e) {
         // Fallback for environments without a DOM or with other issues.
-        return cleaned.replace(/<[^>]*>/g, '');
+        // Repeatly remove HTML tags until no further matches are found
+        let result = cleaned;
+        let prev;
+        do {
+          prev = result;
+          result = result.replace(/<[^>]*>/g, '');
+        } while (result !== prev);
+        return result;
       }
     }
 
     // Final fallback for non-browser environments.
-    return cleaned.replace(/<[^>]*>/g, '');
+    let result = cleaned;
+    let prev;
+    do {
+      prev = result;
+      result = result.replace(/<[^>]*>/g, '');
+    } while (result !== prev);
+    return result;
   }
 
   /**


### PR DESCRIPTION
Potential fix for [https://github.com/quadmangle/improved-forknight/security/code-scanning/3](https://github.com/quadmangle/improved-forknight/security/code-scanning/3)

The best fix is to ensure that the regex replacement for removing HTML tags is applied repeatedly until no further matches are found, as recommended for multi-character sanitization issues. Instead of calling `replace(..., '')` once, wrap it in a loop that continues replacing until the string no longer changes. This applies both where the fallback is used (lines 40 and 45). No change to the surrounding logic or existing imports is needed; only the fallback replacement needs adjustment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
