### PR TITLE
Potential fix for code scanning alert no. 7: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express-session": "1.18.2",
     "express-validator": "7.2.1",
     "helmet": "8.1.0",
-    "cookie": "0.7.2"
+    "cookie": "0.7.2",
+    "lusca": "^1.7.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const { body, validationResult } = require('express-validator');
 const cookie = require('cookie');
+const lusca = require('lusca');
 
 const app = express();
 
@@ -68,6 +69,7 @@ app.use(
     },
   })
 );
+app.use(lusca.csrf());
 
 // ---------- Helpers ----------
 function generateToken() {
@@ -134,9 +136,8 @@ app.use('/api/', requireNonce);
 
 // Issue a CSRF token (separate from nonce). Client should send it back in body.
 app.get('/api/csrf-token', (req, res) => {
-  const token = generateToken();
-  req.session.csrfToken = { value: token, expires: Date.now() + 10 * 60 * 1000 };
-  return res.json({ token });
+  // lusca adds req.csrfToken (getter) after csrf middleware
+  return res.json({ token: req.csrfToken });
 });
 
 // Example validated form: Contact


### PR DESCRIPTION
Potential fix for [https://github.com/quadmangle/improved-forknight/security/code-scanning/7](https://github.com/quadmangle/improved-forknight/security/code-scanning/7)

To properly mitigate CSRF, install and configure a well-known CSRF protection middleware immediately after the session middleware. The recommended approach in Node/Express is to use `lusca.csrf`, as suggested by CodeQL, but `csurf` (an official Express middleware) is also common. For best compatibility, we'll follow the recommendation and use `lusca.csrf`. 

1. **Install the lusca package** (`npm install lusca`).
2. Add `const lusca = require('lusca');` at the top of `server.js` (after other imports).
3. Add `app.use(lusca.csrf());` **after** the session middleware and **before** any state-changing routes.
4. The `/api/session` and `/api/csrf-token` endpoints may need to send the CSRF token to the client. You could keep the dedicated `/api/csrf-token` route, but for forms, lusca will set `req.csrfToken` for templating; in APIs, tokens can be sent manually via JSON.
5. Document (or enforce) that clients **must** send the CSRF token in the appropriate header (default is `x-csrf-token`) in all POST, PUT, DELETE requests.

**Changes required in server.js:**
- Add lusca import.
- Add lusca.csrf middleware, after session.
- Optionally, update `/api/csrf-token` to use `req.csrfToken` from lusca.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
