### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -20,18 +20,9 @@
     }
 
     // 3. If DOMPurify is not available, use a fallback sanitization method.
-    console.warn('DOMPurify not found. Falling back to basic sanitization.');
-    // Regex to find and remove common malicious patterns.
-    // This looks for script tags, javascript:/data:/vbscript: protocols, and on* event handlers.
-    const maliciousPatterns = /<script.*?>.*?<\/script>|javascript:|data:|vbscript:|on\w+=|onerror=|onload=|<\w+[^>]*\s+[^>]*on\w+=/ig;
-    let cleaned = input;
-    let prev;
-    do {
-      prev = cleaned;
-      cleaned = cleaned.replace(maliciousPatterns, '');
-    } while (cleaned !== prev);
-    // Use the browser's own parser to strip any remaining HTML tags.
-    // .textContent ensures no HTML is interpreted.
+    console.warn('DOMPurify not found. Falling back to DOM-based sanitization.');
+    // Use the browser's own parser to strip any HTML tags and neutralize content.
+    // .textContent ensures no HTML is interpreted, including malformed and invalid tags.
     if (typeof document !== 'undefined') {
       try {
         const div = document.createElement('div');
@@ -41,7 +32,7 @@
       } catch (e) {
         // Fallback for environments without a DOM or with other issues.
         // Remove any remaining tags (repeatedly) in environments without DOM.
-        let stripped = cleaned;
+        let stripped = input;
         let prevStripped;
         do {
           prevStripped = stripped;


### PR DESCRIPTION
Potential fix for [https://github.com/quadmangle/improved-forknight/security/code-scanning/1](https://github.com/quadmangle/improved-forknight/security/code-scanning/1)

To fix the problem, we should remove reliance on hand-written regex to filter script tags and other HTML threats. Instead, completely rely on a robust HTML parser and sanitizer for neutralization. If DOMPurify is not available, leverage the browser's DOM parser to safely extract text (`textContent`)—which is already used in the code, but only after the regex filter. This means we should remove the bad regex-fallback sanitization, and (when DOMPurify is unavailable) just use textContent directly as the sanitizer, since textContent strips all HTML tags and content in a trustworthy way. If textContent is not available (e.g., in a non-browser environment), we can only remove all tags with a very generic regex (`/<[^>]*>/g`), but *not* attempt to filter specific HTML structures.

**Steps:**
- Remove the code using the problematic regex (`maliciousPatterns`) and its repeated replace pass.
- Directly fall back to DOM-based sanitization (`textContent`) if DOMPurify is unavailable.
- Only use a plain regex (`/<[^>]*>/g`) in environments with no DOM (final fallback).
- Update the code documentation to reflect that regex-based removal of specific tags is not used any more.

All changes should be confined to the `sanitizeInput` function in `js/utils.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
